### PR TITLE
Add support to validate against OSADL's matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ license: check_license_files
 python: py-test py-sort py-lint check-py-cli
 
 py-test:
-	PYTHONPATH=./python/ pytest --log-cli-level=10 tests/python/
+	PYTHONPATH=python/ python3.10 -m pytest --log-cli-level=10 tests/python/
 
 py-sort:
 	cd python && isort ./*/*.py --diff

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -10,6 +10,7 @@ import logging
 import sys
 
 from flame.license_db import FossLicenses
+from flame.license_db import Validation
 import flame.config
 from flame.format import OUTPUT_FORMATS
 from flame.format import OutputFormatterFactory
@@ -64,6 +65,7 @@ def parse():
     parser_c.add_argument('license', type=str, help='license name to display')
     parser_c.add_argument('--validate-spdx', action='store_true', dest='validate_spdx', help='Validate that the resulting license expression is valid according to SPDX syntax', default=False)
     parser_c.add_argument('--validate-relaxed', action='store_true', dest='validate_relaxed', help='Validate that the resulting license expression is valid according to SPDX syntax, but allow non SPDX identifiers ', default=False)
+    parser_c.add_argument('--validate-osadl', action='store_true', dest='validate_osadl', help='Validate that the resulting licenses are supported by OSADL\'s compatibility matrix', default=False)
 
     # aliases
     parser_a = subparsers.add_parser(
@@ -107,7 +109,8 @@ def compats(fl, formatter, args):
     return formatter.format_compat_list(all_compats, args.verbose)
 
 def compatibility(fl, formatter, args):
-    compatibilities = fl.expression_compatibility_as(args.license, validate_spdx=args.validate_spdx, validate_relaxed=args.validate_relaxed)
+    validations = __validations(args)
+    compatibilities = fl.expression_compatibility_as(args.license, validations)
     return formatter.format_compatibilities(compatibilities, args.verbose)
 
 def license(fl, formatter, args):
@@ -123,6 +126,16 @@ def full_license(fl, formatter, args):
     else:
         raise FlameException(f'You can only provide one license to license-full. "{args.license} not allowed"')
 
+def __validations(args):
+    validations = []
+    if args.validate_spdx:
+        validations.append(Validation.SPDX)
+    if args.validate_relaxed:
+        validations.append(Validation.RELAXED)
+    if args.validate_osadl:
+        validations.append(Validation.OSADL)
+
+    return validations
 
 def main():
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,4 +5,5 @@
 jsonschema
 PyYAML
 license_expression
+osadl_matrix
 

--- a/tests/licenses/no-compat.json
+++ b/tests/licenses/no-compat.json
@@ -1,0 +1,14 @@
+{
+    "meta": {
+        "disclaimer": "bla bla ",
+	"comment": "adapting to new format"
+    },
+    "spdxid": "LicenseRef-dummy-no-compat",
+    "scancode_key": "no-no-no",
+    "name": "No no license",
+    "aliases": [
+        "No no license"
+    ],
+    "license_text_url": "",
+    "comment": "This license does not exist."
+}

--- a/tests/python/test_compat.py
+++ b/tests/python/test_compat.py
@@ -10,6 +10,7 @@ import sys
 import pytest
 
 from flame.license_db import FossLicenses
+from flame.license_db import Validation
 from flame.exception import FlameException
 import logging
 
@@ -22,7 +23,6 @@ def test_compat_misc_blanks():
             for k in range(1,10):
                 c = fl.expression_compatibility_as(f'{" "*i}GPLv2+{" "*j}&& BSD3{" "*k}')
                 assert c['compat_license'] == "GPL-2.0-or-later AND BSD-3-Clause"
-
 
 def compat_misc_paranthesises_sub(lic1, op, lic2, expected):
     for i in range(1,3):
@@ -40,3 +40,16 @@ def test_compat_misc_paranthesises():
     for op in [ '|', '||', 'or', 'OR' ]:
         compat_misc_paranthesises_sub('GPLv2+', op, 'bsd-new', 'GPL-2.0-or-later OR BSD-3-Clause')
 
+def test_compat_validations():
+
+    c = fl.expression_compatibility_as(f'No no license')
+    assert c['compat_license'] == "LicenseRef-dummy-no-compat"
+
+    c = fl.expression_compatibility_as(f'No no license', [Validation.RELAXED])
+    assert c['compat_license'] == "LicenseRef-dummy-no-compat"
+
+    with pytest.raises(FlameException) as _error:
+        c = fl.expression_compatibility_as(f'No no license', [Validation.SPDX])
+
+    with pytest.raises(FlameException) as _error:
+        c = fl.expression_compatibility_as(f'No no license', [Validation.OSADL])

--- a/tests/python/test_ldb.py
+++ b/tests/python/test_ldb.py
@@ -18,7 +18,7 @@ fl = FossLicenses(check=True, license_dir="tests/licenses", logging_level=loggin
 def test_alias_list():
     # list of all aliases
     aliases = fl.aliases_list()
-    assert len(aliases) == 5
+    assert len(aliases) == 6
 
 def test_alias_list_gpl():
     # list of all aliases with license with GPL


### PR DESCRIPTION
Add --validate-osadl option to python program

Add support for checking if a license has a compatibility
    
Add validation against OSADL's matrix
    
Add Validation class/enum to easier pass validation choices

