### PR TITLE
Add feature to output unknown symbols from a license

### DIFF
--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -163,9 +163,8 @@ def unknown(fl, formatter, args):
     compat_licenses = [x for x in compat_licenses if x]
     unknown_symbols = set()
     for compat_license in compat_licenses:
-        if not compat_license in fl.known_symbols():
+        if compat_license not in fl.known_symbols():
             unknown_symbols.add(compat_license)
-    warnings = None
     if len(unknown_symbols) != 0:
         raise FlameException('Unknown symbols identified.\n' + '\n'.join(list(unknown_symbols)))
     return 'OK', None

--- a/python/flame/exception.py
+++ b/python/flame/exception.py
@@ -11,4 +11,7 @@ class FlameException(Exception):
         self._problems = problems
 
     def problems(self):
-        return self._problems
+        if self._problems:
+            return self._problems
+        else:
+            return ''

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import boolean
 import collections
 import glob
 import json
@@ -337,7 +338,11 @@ class FossLicenses:
         # Manage dual licenses (such as GPL-2.0-or-later)
         updates_object = self.__update_or_later(ret['license_expression'])
         updates = updates_object['updates']
-        updated_license = str(self.license_expression.parse(updates_object['license_expression']))
+        try:
+            updated_license = str(self.license_expression.parse(updates_object['license_expression']))
+        except boolean.boolean.ParseError as e:
+            raise FlameException(f'Could not parse \"{updates_object["license_expression"]}\". Exception: {e}')
+
 
         if update_dual:
             license_parsed = updated_license

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -486,6 +486,18 @@ class FossLicenses:
         # List all aliases that exist
         return self.license_db[FLAME_ALIASES_TAG]
 
+    def ambiguities_list(self):
+        """Returns a list of all the ambigious licenses. 
+
+        :Example:
+
+        >>> fl = FossLicenses()
+        >>> aliases = fl.ambiguities_list()
+
+        """
+        # List all aliases that exist
+        return self.license_db[AMBIG_TAG]
+
     def aliases(self, license_name):
         """Returns a list of all the aliases for a license
 

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -343,7 +343,6 @@ class FossLicenses:
         except boolean.boolean.ParseError as e:
             raise FlameException(f'Could not parse \"{updates_object["license_expression"]}\". Exception: {e}')
 
-
         if update_dual:
             license_parsed = updated_license
         else:
@@ -487,7 +486,7 @@ class FossLicenses:
         return self.license_db[FLAME_ALIASES_TAG]
 
     def ambiguities_list(self):
-        """Returns a list of all the ambigious licenses. 
+        """Returns a list of all the ambigious licenses.
 
         :Example:
 
@@ -498,9 +497,8 @@ class FossLicenses:
         # List all aliases that exist
         return self.license_db[AMBIG_TAG]
 
-
     def known_symbols(self):
-        """Returns a list of all all known license symbols. 
+        """Returns a list of all all known license symbols.
 
         :Example:
 
@@ -509,7 +507,7 @@ class FossLicenses:
 
         """
         _symbols = set()
-        
+
         ambiguities = self.ambiguities_list()['ambiguities']
         for ambig in ambiguities:
             _symbols.add(ambig)
@@ -525,7 +523,7 @@ class FossLicenses:
             _symbols.add(op)
 
         return list(_symbols)
-    
+
     def aliases(self, license_name):
         """Returns a list of all the aliases for a license
 

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -498,6 +498,34 @@ class FossLicenses:
         # List all aliases that exist
         return self.license_db[AMBIG_TAG]
 
+
+    def known_symbols(self):
+        """Returns a list of all all known license symbols. 
+
+        :Example:
+
+        >>> fl = FossLicenses()
+        >>> aliases = fl.known_symbols()
+
+        """
+        _symbols = set()
+        
+        ambiguities = self.ambiguities_list()['ambiguities']
+        for ambig in ambiguities:
+            _symbols.add(ambig)
+            _symbols.update(set(ambiguities[ambig]['aliases']))
+
+        licenses = self.license_db[LICENSES_TAG]
+        for lic in licenses:
+            _symbols.add(lic)
+            _symbols.update(set(licenses[lic]['aliases']))
+
+        operators = self.license_db[LICENSE_OPERATORS_TAG]
+        for op in operators:
+            _symbols.add(op)
+
+        return list(_symbols)
+    
     def aliases(self, license_name):
         """Returns a list of all the aliases for a license
 


### PR DESCRIPTION
**Check for unknown symbols (without there being any unknown symbols)**
```
$ flame unknown BSD3
OK
```

**Check for unknown symbols (with BSD100 which is (yet) a license**
```
$ flame  unknown BSD100
Error: Unknown symbols identified.
BSD100
```

This is a useful feature to get an easy to read (and parse) list of licenses that need to be added to foss-licenses.