### PR TITLE
Fix alias command

### DIFF
--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -115,7 +115,7 @@ def get_parser():
     parser_a = subparsers.add_parser(
         'aliases', help='Display all aliases')
     parser_a.set_defaults(which='aliases', func=aliases)
-    parser_a.add_argument('--license', '-l', type=str, dest='alias_license', help='List only the aliases for licenses containing the given string', default=None)
+    parser_a.add_argument('--include-license', '-il', type=str, dest='include_license', help='List only the aliases for licenses containing the given string (case insensitive)', default=None)
 
     # compatbilities
     parser_cs = subparsers.add_parser(
@@ -149,7 +149,7 @@ def operators(fl, formatter, args):
     return formatter.format_operators(all_op, args.verbose)
 
 def aliases(fl, formatter, args):
-    all_aliases = fl.alias_list(args.alias_license)
+    all_aliases = fl.alias_list(args.include_license)
     return formatter.format_alias_list(all_aliases, args.verbose)
 
 def licenses(fl, formatter, args):

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -481,7 +481,7 @@ class FossLicenses:
 
         """
         if alias_license:
-            return {k: v for k, v in self.license_db[FLAME_ALIASES_TAG].items() if alias_license in v}
+            return {k: v for k, v in self.license_db[FLAME_ALIASES_TAG].items() if alias_license.lower() in v.lower()}
         # List all aliases that exist
         return self.license_db[FLAME_ALIASES_TAG]
 


### PR DESCRIPTION
Addressing and closes #149 

These commits:
* makes license expression case insensitive
* makes matching license expression not crashing

Example
```
$ PYTHONPATH=./python ./python/flame/__main__.py aliases -il MIT | head -10
MITNFA -> MITNFA
MIT +no-false-attribs license -> MITNFA
MIT (NFA) License -> MITNFA
MIT +no-false-attribs License -> MITNFA
scancode://mit-no-false-attribs -> MITNFA
MIT no false attribution License -> MITNFA
scancode:mit-no-false-attribs -> MITNFA
MIT-advertising -> MIT-advertising
MIT License (with advertising) -> MIT-advertising
MIT with advertising -> MIT-advertising
..... snip
``` 

