### PR TITLE
Add ambuities command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,18 @@ py-release: check clean build
 	@echo "To upload: "
 	@echo "twine upload --repository foss-flame --verbose  dist/*"
 
+stats:
+	@echo -n "licenses:     "
+	@PYTHONPATH=./python ./python/flame/__main__.py licenses | wc -l
+	@echo -n "aliases:      "
+	@PYTHONPATH=./python ./python/flame/__main__.py aliases | wc -l
+	@echo -n "compats:      "
+	@PYTHONPATH=./python ./python/flame/__main__.py compats | wc -l
+	@echo -n "operators:    "
+	@PYTHONPATH=./python ./python/flame/__main__.py operators | wc -l
+	@echo -n "ambiguities:  "
+	@PYTHONPATH=./python ./python/flame/__main__.py ambiguities | wc -l
+
 clean:
 	find . -name "*~"    | xargs rm -fr
 	find . -name "*.pyc" | xargs rm -fr

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -117,20 +117,25 @@ def get_parser():
     parser_a.set_defaults(which='aliases', func=aliases)
     parser_a.add_argument('--include-license', '-il', type=str, dest='include_license', help='List only the aliases for licenses containing the given string (case insensitive)', default=None)
 
+    # ambiguities
+    parser_os = subparsers.add_parser(
+        'ambiguities', help='Display all ambiguities')
+    parser_os.set_defaults(which='ambiguities', func=ambiguities)
+
     # compatbilities
     parser_cs = subparsers.add_parser(
         'compats', help='Display all compatibilities')
     parser_cs.set_defaults(which='compats', func=compats)
 
-    # operators
-    parser_os = subparsers.add_parser(
-        'operators', help='Display all operators')
-    parser_os.set_defaults(which='operators', func=operators)
-
     # licenses
     parser_cs = subparsers.add_parser(
         'licenses', help='show all licenses')
     parser_cs.set_defaults(which='licenses', func=licenses)
+
+    # operators
+    parser_os = subparsers.add_parser(
+        'operators', help='Display all operators')
+    parser_os.set_defaults(which='operators', func=operators)
 
     # unknown
     parser_u = subparsers.add_parser(
@@ -143,6 +148,10 @@ def get_parser():
 def parse():
 
     return get_parser().parse_args()
+
+def ambiguities(fl, formatter, args):
+    all_ambiguities = fl.ambiguities_list()
+    return formatter.format_ambiguities(all_ambiguities)
 
 def operators(fl, formatter, args):
     all_op = fl.operators()

--- a/python/flame/format.py
+++ b/python/flame/format.py
@@ -214,7 +214,7 @@ class OutputFormatter():
         :type all_aliases: list
         :param verbose: provide additional information
         :type verbose: boolean
-        :raise FlameException: if all_compats is not valid
+        :raise FlameException: if compats is not valid
         :return: formatted string
         :rtype: str
 
@@ -237,7 +237,7 @@ class OutputFormatter():
         :type operators: list
         :param verbose: provide additional information
         :type verbose: boolean
-        :raise FlameException: if all_compats is not valid
+        :raise FlameException: if operators is not valid
         :return: formatted string
         :rtype: str
 
@@ -248,6 +248,29 @@ class OutputFormatter():
         >>> operators = fl.operators()
         >>> formatter = OutputFormatterFactory.formatter("TEXT")
         >>> formatted = formatter.format_operators(operators)
+
+        """
+        return None, None
+
+    def format_ambiguities(self, ambiguities, verbose=False):
+        """
+        Return a formatted string of the existing ambiguities
+
+        :param operators: A list of ambiguites.
+        :type operators: list
+        :param verbose: provide additional information
+        :type verbose: boolean
+        :raise FlameException: if ambiguites is not valid
+        :return: formatted string
+        :rtype: str
+
+        :Example:
+
+        >>> from flame.license_db import FossLicenses
+        >>> fl = FossLicenses()
+        >>> ambiguities = fl.ambiguities_list()
+        >>> formatter = OutputFormatterFactory.formatter("TEXT")
+        >>> formatted = formatter.format_ambiguities(ambiguities)
 
         """
         return None, None
@@ -285,6 +308,9 @@ class JsonOutputFormatter(OutputFormatter):
     def format_operators(self, operators, verbose=False):
         return json.dumps(operators), None
 
+    def format_ambiguities(self, ambiguities, verbose=False):
+        return json.dumps(ambiguities), None
+
 class YamlOutputFormatter(OutputFormatter):
 
     def format_compat(self, compat, verbose=False):
@@ -313,6 +339,9 @@ class YamlOutputFormatter(OutputFormatter):
 
     def format_operators(self, operators, verbose=False):
         return yaml.safe_dump(operators), None
+
+    def format_ambiguities(self, ambiguities, verbose=False):
+        return yaml.safe_dump(ambiguities), None
 
 class TextOutputFormatter(OutputFormatter):
 
@@ -376,6 +405,12 @@ class TextOutputFormatter(OutputFormatter):
 
     def format_operators(self, operators, verbose=False):
         return '\n'.join([f'{k} -> {v}' for k, v in operators.items()]), None
+
+    def format_ambiguities(self, ambiguities, verbose=False):
+        ret = []
+        for k, v in ambiguities.items():
+            ret += [f'{a} -> {k}' for a in v['aliases']]
+        return '\n'.join(ret), None
 
     def format_error(self, error, verbose=False):
         return f'Error: {error}', None

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -498,7 +498,7 @@ class FossLicenses:
 
         """
         # List all aliases that exist
-        return self.license_db[AMBIG_TAG]
+        return self.license_db[AMBIG_TAG]['ambiguities']
 
     def known_symbols(self):
         """Returns a list of all all known license symbols.
@@ -511,7 +511,7 @@ class FossLicenses:
         """
         _symbols = set()
 
-        ambiguities = self.ambiguities_list()['ambiguities']
+        ambiguities = self.ambiguities_list()
         for ambig in ambiguities:
             _symbols.add(ambig)
             _symbols.update(set(ambiguities[ambig]['aliases']))


### PR DESCRIPTION
Add a command to output the known ambiguities:

```
$ flame ambiguities 
License :: OSI Approved :: Academic Free License (AFL) -> Academic Free License
AFLv2 -> Academic Free License
Apache License -> Apache License
Apache Software License -> Apache License
OSI Approved :: Apache Software License -> Apache License
The Apache Software License -> Apache License
...... snip
```

... and as a reminder, ambiguities are used to notify caller/user like this:

```
$ flame license BSD-Style
Warnings: An ambiguity was identified in "BSD-Style". The ambiguous license is "BSD", identified via "BSD-Style". Problem: There are a couple of variants or versions of the BSD license (0BSD, BSD-1-Clause, BSD-2-Clause, BSD-3-Clause and BSD-4-Clause). Without the version/variant of the license it is not possible to determine which of the versions is meant.
BSD-Style
```
