### PR TITLE
Bugfixes

### DIFF
--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -191,7 +191,7 @@ def version_info(fl, formatter, args):
 
 def compatibility(fl, formatter, args):
     validations = __validations(args)
-    compatibilities = fl.expression_compatibility_as(' '.join(args.license), validations)
+    compatibilities = fl.expression_compatibility_as(' '.join(args.license), validations, update_dual=(not args.no_dual_update))
     return formatter.format_compatibilities(compatibilities, args.verbose)
 
 def show_license(fl, formatter, args):

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -356,7 +356,7 @@ class FossLicenses:
 
         tmp_license_expression = ret['license_expression']
         for alias in reversed(collections.OrderedDict(sorted(aliases.items(), key=lambda x: len(x[0])))):
-            needle = r'(?:\s+|^)%s(?:\s+|$)' % alias
+            needle = r'(?:\s+|^)%s(?:\s+|$)' % re.escape(alias)
             if re.search(needle, tmp_license_expression):
                 real_lic = self.license_db[AMBIG_TAG]['aliases'][alias]
                 if alias != real_lic:


### PR DESCRIPTION
Fixes for:
* if a license contains "+", the plus is treated as part of a reg exp. Escaping the license (alias) solves the problem
* when listing compatibilities the flag on whether or not to update dual license was not passed. Now it is