### PR TITLE
Return ambig values, not only description

### DIFF
--- a/python/flame/format.py
+++ b/python/flame/format.py
@@ -395,7 +395,8 @@ class TextOutputFormatter(OutputFormatter):
                 ret.append(f' * "{compat["queried_name"]}" -> "{compat["name"]}" via "{compat["identified_via"]}"')
 
         if compats['ambiguities']:
-            warnings = f'Warnings: {", ".join(compats["ambiguities"])}'
+            descr = [x['description'] for x in compats['ambiguities']]
+            warnings = f'Warnings: {", ".join(descr)}'
         else:
             warnings = None
 
@@ -420,7 +421,8 @@ class TextOutputFormatter(OutputFormatter):
             for identification in expression['identifications']:
                 ret.append(f' * "{identification["queried_name"]}" -> "{identification["name"]}" via "{identification["identified_via"]}"')
         if expression['ambiguities']:
-            warnings = f'Warnings: {", ".join(expression["ambiguities"])}'
+            descr = [x['description'] for x in expression['ambiguities']]
+            warnings = f'Warnings: {", ".join(descr)}'
         else:
             warnings = None
         return '\n'.join(ret), warnings

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -345,7 +345,12 @@ class FossLicenses:
                 else:
                     about_license = f'An ambiguity was identified in "{ret["license_expression"]}". The ambiguous license is "{real_lic}"-'
                 problem = self.license_db[AMBIG_TAG]["ambiguities"][real_lic]["problem"]
-                ambiguities.append(f'{about_license} Problem: {problem}')
+                ambiguities.append({
+                    'license': ret['license_expression'],
+                    'ambigous_license': real_lic,
+                    'problem': problem,
+                    'description': f'{about_license} Problem: {problem}',
+                })
                 tmp_license_expression = re.sub(needle, ' ', tmp_license_expression)
 
         update_problem = None


### PR DESCRIPTION
Currently a descriptive string is returned to explain the identified ambiguity. With these commit the ambiguity data is provided as values so the recipient can easier extract and use the information.