### PR TITLE
Add pypi classifiers, part ii

### DIFF
--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -559,7 +559,7 @@ class FossLicenses:
                 for alias in aliases:
                     ambig_aliases[alias] = ambig
 
-            for alias in  reversed(collections.OrderedDict(sorted(ambig_aliases.items(), key=lambda x: len(x[0])))):
+            for alias in reversed(collections.OrderedDict(sorted(ambig_aliases.items(), key=lambda x: len(x[0])))):
                 if alias in fixed_license_expression:
                     fixed_license_expression = re.sub(re.escape(alias), ambig, fixed_license_expression)
                     break

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -549,16 +549,19 @@ class FossLicenses:
         license_expression = ' '.join(_license_expression)
 
         try:
-            compat_license_expression = self.expression_license(license_expression, validations=validations)
+            compat_license_expression = self.expression_license(license_expression, validations=validations, update_dual=False)
             fixed_license_expression = compat_license_expression['identified_license']
         except Exception:
             fixed_license_expression = license_expression
+            ambig_aliases = {}
+            for ambig in self.ambiguities_list():
+                aliases = self.license_db[AMBIG_TAG]['ambiguities'][ambig]['aliases']
+                for alias in aliases:
+                    ambig_aliases[alias] = ambig
 
-        for ambig in self.ambiguities_list():
-            aliases = self.license_db[AMBIG_TAG]['ambiguities'][ambig]['aliases']
-            for alias in sorted(aliases, key=len, reverse=True):
+            for alias in  reversed(collections.OrderedDict(sorted(ambig_aliases.items(), key=lambda x: len(x[0])))):
                 if alias in fixed_license_expression:
-                    fixed_license_expression = re.sub(f'\s{alias}\s', '...', fixed_license_expression)
+                    fixed_license_expression = re.sub(re.escape(alias), ambig, fixed_license_expression)
                     break
 
         compat_licenses = [x.strip() for x in re.split(LICENSE_SPLIT_RE, fixed_license_expression)]

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -52,9 +52,9 @@ statistics = False
 
 [tool:pytest]
 addopts =
-    --cov=flame --cov-report term-missing
-    --forked
-    --no-header
-    --quiet
-    --random-order --random-order-bucket=global
+#    --cov=flame --cov-report term-missing
+#    --forked
+#    --no-header
+#    --quiet
+#    --random-order --random-order-bucket=global
     --showlocals

--- a/tests/shell/sanity-check.sh
+++ b/tests/shell/sanity-check.sh
@@ -74,11 +74,6 @@ check_file_presence()
 
 check_presence()
 {
-    echo $*
-}
-
-check_presence()
-{
     LICENSE=$1
     FILE=var/licenses/$LICENSE.json
     

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -154,6 +154,14 @@
             ],
             "problem": "There a couple of licenses related to the GNU project. Without the name of the license and version number it is not possible to determine which of the versions is meant."
         },
+        "GNU Free Documentation License": {
+            "aliases": [
+                "GNU FDL",
+                "GFDL",
+                "License :: OSI Approved :: GNU Free Documentation License (FDL)"
+            ],
+            "problem": "This license has different version (1.1, 1.2 and 1.3). Without a version number it is not possible to determine which of the versions is meant."
+        },
         "GNU General Public License": {
             "aliases": [
                 "GPL",
@@ -163,7 +171,8 @@
                 "GPL-unspecified",
                 "GPL License",
                 "GNU GENERAL PUBLIC LICENSE",
-                "License :: OSI Approved :: GNU General Public License"
+                "License :: OSI Approved :: GNU General Public License",
+                "License :: OSI Approved :: GNU General Public License (GPL)"
             ],
             "problem": "This license has different version (1, 2 and 3). Without a version number it is not possible to determine which of the versions is meant."
         },
@@ -187,7 +196,9 @@
                 "GNU LESSER GENERAL PUBLIC LICENSE",
                 "Lesser General Public License",
                 "License :: OSI Approved :: GNU Library or...",
-                "License :: OSI Approved :: GNU Lesser General Public License v2"
+                "License :: OSI Approved :: GNU Lesser General Public License v2",
+                "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
+                "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
             ],
             "problem": "This license has different versions (2.0, 2.1 and 3.0). Without a version number it is not possible to determine which of the versions is meant."
         },
@@ -213,6 +224,19 @@
             ],
             "problem": "This license has different version (1.0, 1.1 and 2.0). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },
+        "Netscape Public License": {
+            "aliases": [
+                "License :: Netscape Public License (NPL)",
+                "NPL"
+            ],
+            "problem": "This license has different version (1.0 and 1.1). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
+        },
+        "OSI Approved": {
+            "aliases": [
+                "License :: OSI Approved"
+            ],
+            "problem": "OSI has approved many licenses. You It is not possible to determine which license is meant with this information."
+        },
         "Python Software Foundation License": {
             "aliases": [
                 "PSF",
@@ -226,6 +250,12 @@
                 "Python Software Foundation"
             ],
             "problem": "This license has different versions (2.0 and 2.0.1). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
+        },
+        "Sun Industry Standards Source License": {
+            "aliases": [
+                "License :: OSI Approved :: Sun Industry Standards Source License (SISSL)"
+            ],
+            "problem": "This license has different versions (1.0, 1.1 and 1.2). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },
         "Zope Public License": {
             "aliases": [

--- a/var/licenses/0BSD.json
+++ b/var/licenses/0BSD.json
@@ -20,6 +20,7 @@
         "Zero-Clause BSD",
         "bsd-zero",
         "BSD 0 Clause License",
-        "License :: OSI Approved :: Zero-Clause BSD"
+        "License :: OSI Approved :: Zero-Clause BSD",
+        "License :: OSI Approved :: Zero-Clause BSD (0BSD)"
   ]
 }

--- a/var/licenses/AGPL-3.0-or-later.json
+++ b/var/licenses/AGPL-3.0-or-later.json
@@ -46,6 +46,7 @@
         "scancode:agpl-3.0-plus",
         "agpl-3.0-plus",
         "AGPLv3.0+",
-        "AGPL-3+"
+        "AGPL-3+",
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"
     ]
 }

--- a/var/licenses/BSL-1.0.json
+++ b/var/licenses/BSL-1.0.json
@@ -28,6 +28,7 @@
         "Boost-1.0",
         "Boost Software license 1.0",
         "boost-1.0",
-        "BOOST-1.0"
+        "BOOST-1.0",
+        "License :: OSI Approved :: Boost Software License 1.0 (BSL-1.0)"
     ]
 }

--- a/var/licenses/BlueOak-1.0.0.json
+++ b/var/licenses/BlueOak-1.0.0.json
@@ -12,6 +12,7 @@
         "Blue Oak Model License Version 1.0.0",
         "scancode:blueoak-1.0.0",
         "blueoak-1.0.0",
-        "License :: OSI Approved :: Blue Oak Model License"
+        "License :: OSI Approved :: Blue Oak Model License",
+        "License :: OSI Approved :: Blue Oak Model License (BlueOak-1.0.0)"
     ]
 }

--- a/var/licenses/CC0-1.0.json
+++ b/var/licenses/CC0-1.0.json
@@ -20,6 +20,7 @@
         "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "CC0",
         "CC0 1.0 Universal",
-        "License :: CC0 1.0 Universal"
+        "License :: CC0 1.0 Universal",
+        "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication"
     ]
 }

--- a/var/licenses/CDDL-1.0.json
+++ b/var/licenses/CDDL-1.0.json
@@ -24,6 +24,7 @@
         "osi:CDDL-1.0",
         "Common Development and Distribution License 1.0 (CDDL-1.0)",
         "cddl-1.0",
-        "License :: OSI Approved :: Common Development and Distribution License 1.0"
+        "License :: OSI Approved :: Common Development and Distribution License 1.0",
+        "License :: OSI Approved :: Common Development and Distribution License 1.0 (CDDL-1.0)"
     ]
 }

--- a/var/licenses/CECILL-B.json
+++ b/var/licenses/CECILL-B.json
@@ -18,6 +18,7 @@
         "https://spdx.org/licenses/cecill-b",
         "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html",
         "scancode:cecill-b",
-        "License :: CeCILL-B Free Software License Agreement"
+        "License :: CeCILL-B Free Software License Agreement",
+        "License :: CeCILL-B Free Software License Agreement (CECILL-B)"
     ]
 }

--- a/var/licenses/EPL-1.0.json
+++ b/var/licenses/EPL-1.0.json
@@ -40,6 +40,7 @@
         "Eclipse-Public-License-v1.0",
         "EPL - v 1.0",
         "Eclipse Public License - v 1.0",
-        "License :: OSI Approved :: Eclipse Public License 1.0"
+        "License :: OSI Approved :: Eclipse Public License 1.0",
+        "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)"
     ]
 }

--- a/var/licenses/EPL-2.0.json
+++ b/var/licenses/EPL-2.0.json
@@ -34,6 +34,7 @@
         "scancode:epl-2.0",
         "osi:EPL-2.0",
         "Eclipse Public License 2.0 (EPL-2.0)",
-        "License :: OSI Approved :: Eclipse Public License 2.0"
+        "License :: OSI Approved :: Eclipse Public License 2.0",
+        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"
     ]
 }

--- a/var/licenses/EUPL-1.0.json
+++ b/var/licenses/EUPL-1.0.json
@@ -23,6 +23,7 @@
         "scancode:eupl-1.0",
         "European Union Public Licence 1.0 (EUPL 1.0)",
         "eupl-1.0",
-        "License :: OSI Approved :: European Union Public Licence 1.0"
+        "License :: OSI Approved :: European Union Public Licence 1.0",
+        "License :: OSI Approved :: European Union Public Licence 1.0 (EUPL 1.0)"
     ]
 }

--- a/var/licenses/EUPL-1.2.json
+++ b/var/licenses/EUPL-1.2.json
@@ -22,6 +22,7 @@
         "European Union Public Licence V. 1.2",
         "scancode:eupl-1.2",
         "osi:EUPL-1.2",
-        "License :: OSI Approved :: European Union Public Licence 1.2"
+        "License :: OSI Approved :: European Union Public Licence 1.2",
+        "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)"
     ]
 }

--- a/var/licenses/GPL-2.0-or-later.json
+++ b/var/licenses/GPL-2.0-or-later.json
@@ -56,6 +56,7 @@
         "GPL 2+",
         "GPLV2+",
         "gpl-2.0-plus",
-        "License :: OSI Approved :: GNU General Public License v2 or later"
+        "License :: OSI Approved :: GNU General Public License v2 or later",
+        "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)"
     ]
 }

--- a/var/licenses/GPL-3.0-or-later.json
+++ b/var/licenses/GPL-3.0-or-later.json
@@ -54,6 +54,7 @@
         "GPLv3.0+",
         "GPL 3+",
         "gpl-3.0-plus",
-        "License :: OSI Approved :: GNU General Public License v3 or later"
+        "License :: OSI Approved :: GNU General Public License v3 or later",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
     ]
 }

--- a/var/licenses/HPND.json
+++ b/var/licenses/HPND.json
@@ -18,6 +18,7 @@
         "Historical Permission Notice and Disclaimer (HPND)",
         "HPND License",
         "historical",
-        "License :: OSI Approved :: Historical Permission Notice and Disclaimer"
+        "License :: OSI Approved :: Historical Permission Notice and Disclaimer",
+        "License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)"
     ]
 }

--- a/var/licenses/LGPL-3.0-or-later.json
+++ b/var/licenses/LGPL-3.0-or-later.json
@@ -96,6 +96,7 @@
         "GNU Lesser General Public License (LGPL) version 3 or later",
         "scancode:lgpl-3.0-plus",
         "GNU Lesser General Public License v3 or later (LGPLv3+)",
-        "lgpl-3.0-plus"
+        "lgpl-3.0-plus",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)"
     ]
 }

--- a/var/licenses/MIT-0.json
+++ b/var/licenses/MIT-0.json
@@ -21,6 +21,7 @@
         "MIT No Attribution License (MIT-0)",
         "MIT0",
         "The MIT-0 Software License",
-        "License :: OSI Approved :: MIT No Attribution License"
+        "License :: OSI Approved :: MIT No Attribution License",
+        "License :: OSI Approved :: MIT No Attribution License (MIT-0)"
   ]
 }

--- a/var/licenses/MulanPSL-2.0.json
+++ b/var/licenses/MulanPSL-2.0.json
@@ -11,6 +11,7 @@
         "Mulan Permissive Software License, Version 2",
         "mulanpsl-2.0",
         "Mulan PSL v2",
-        "scancode://mulanpsl-2.0"
+        "scancode://mulanpsl-2.0",
+        "License :: OSI Approved :: Mulan Permissive Software License v2 (MulanPSL-2.0)"
     ]
 }

--- a/var/licenses/Nokia.json
+++ b/var/licenses/Nokia.json
@@ -21,6 +21,7 @@
         "NOKOS License",
         "NOKOS",
         "osi:nokia",
-        "scancode:nokos-1.0a"
+        "scancode:nokos-1.0a",
+        "License :: Nokia Open Source License (NOKOS)"
     ]
 }

--- a/var/licenses/OFL-1.1.json
+++ b/var/licenses/OFL-1.1.json
@@ -20,6 +20,7 @@
         "scancode:ofl-1.1",
         "osi:OFL-1.1",
         "SIL Open Font License 1.1 (OFL-1.1)",
-        "License :: OSI Approved :: SIL Open Font License 1.1"
+        "License :: OSI Approved :: SIL Open Font License 1.1",
+        "License :: OSI Approved :: SIL Open Font License 1.1 (OFL-1.1)"
     ]
 }

--- a/var/licenses/OSL-3.0.json
+++ b/var/licenses/OSL-3.0.json
@@ -16,6 +16,7 @@
         "Open Software License",
         "osi:OSL-3.0",
         "scancode:osl-3.0",
-        "License :: OSI Approved :: Open Software License 3.0"
+        "License :: OSI Approved :: Open Software License 3.0",
+        "License :: OSI Approved :: Open Software License 3.0 (OSL-3.0)"
     ]
 }

--- a/var/licenses/UPL-1.0.json
+++ b/var/licenses/UPL-1.0.json
@@ -16,6 +16,7 @@
         "UPL-1.0",
         "osi:UPL",
         "scancode:upl-1.0",
-        "License :: OSI Approved :: Universal Permissive License"
+        "License :: OSI Approved :: Universal Permissive License",
+        "License :: OSI Approved :: Universal Permissive License (UPL)"
     ]
 }

--- a/var/licenses/Unlicense.json
+++ b/var/licenses/Unlicense.json
@@ -15,6 +15,7 @@
         "The Unlicense (Unlicense)",
         "The Unlincence",
         "UNLICENSED",
-        "License :: OSI Approved :: The Unlicense"
+        "License :: OSI Approved :: The Unlicense",
+        "License :: OSI Approved :: The Unlicense (Unlicense)"
     ]
 }


### PR DESCRIPTION
# Add aliases for
* 0BSD
* AGPL-3.0-or-later
* BSL-1.0
* BlueOak-1.0.0
* CC0-1.0
* CDDL-1.0
* CECILL-B
* EPL-1.0
* EPL-2.0
* EUPL-1.0
* EUPL-1.2
* GPL-2.0-or-later
* GPL-3.0-or-later
* HPND
* LGPL-3.0-or-later
* MIT-0
* MulanPSL-2.0
* Nokia
* OFL-1.1
* OSL-3.0
* UPL-1.0
* Unlicense

# Add ambig aliases for
* GPL
* LGPL

# Add ambig 
* GFDL
* Netscape
* OSI
* SISSL
