### PR TITLE
Add curl aliases

### DIFF
--- a/var/licenses/curl.json
+++ b/var/licenses/curl.json
@@ -1,21 +1,25 @@
 {
-  "meta": {
-    "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
-    "comment": ""
-  },
-  "name": "cURL License",
-  "scancode_key": "curl",
-  "spdxid": "curl",
-  "aliases": [
-    "curl",
-    "curl License",
-    "Permission Terms (curl)",
-    "scancode://curl",
-    "cURL License",
-    "CURL LICENSE",
-    "CURL License",
-    "Curl License",
-    "curl license",
-    "scancode:curl"
+    "meta": {
+        "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
+        "comment": ""
+    },
+    "name": "cURL License",
+    "scancode_key": "curl",
+    "spdxid": "curl",
+    "aliases": [
+        "curl",
+        "curl License",
+        "Permission Terms (curl)",
+        "scancode://curl",
+        "cURL License",
+        "CURL LICENSE",
+        "CURL License",
+        "Curl License",
+        "curl license",
+        "scancode:curl",
+        "Curl",
+        "curl licence",
+        "Libcurl license",
+        "MIT License (Customized with curl note)"
   ]
 }


### PR DESCRIPTION
Adding some more curl aliases:
- The curl License
- Curl
- curl licence
- Libcurl license
- MIT License (Customized with curl note)
