### PR TITLE
Add licenses bulk 023

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Current support:
 |Type            | Number |
 |----------------|--------|
 |Licenses        | 184    |
-|Aliases         | 2536     |
+|Aliases         | 2550     |
 |Compatibilities | 23     |
 |Operators       | 14   |
-|Ambiguities     | 147 |
-|Compounds       | 33   |
+|Ambiguities     | 149 |
+|Compounds       | 35   |
 
 # About
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,8 +2,8 @@
 |Type            | Number |
 |----------------|--------|
 |Licenses        | 184    |
-|Aliases         | 2536     |
+|Aliases         | 2550     |
 |Compatibilities | 23     |
 |Operators       | 14   |
-|Ambiguities     | 147 |
-|Compounds       | 33   |
+|Ambiguities     | 149 |
+|Compounds       | 35   |

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -272,7 +272,9 @@
                 "Python Software License",
                 "Python-Software-Foundation-License",
                 "Python Software Foundation",
-                "Python Software Foundation License (PSFL)"
+              "Python Software Foundation License (PSFL)",
+              "The Python Software Foundation License",
+              "PSF-License"
             ],
             "problem": "This license has different versions (2.0 and 2.0.1). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },

--- a/var/compounds.json
+++ b/var/compounds.json
@@ -40,7 +40,8 @@
         {
             "spdxid": "GPL-2.0-only WITH Linux-syscall-note",
             "aliases": [
-                "GPL-2.0-only WITH Linux-syscall-note-exception"
+              "GPL-2.0-only WITH Linux-syscall-note-exception",
+              "GPL-2 with Linux-syscall-note exception"
             ],
             "compatibility_as": "GPL-2.0-only WITH Classpath-exception-2.0"
         },
@@ -85,7 +86,8 @@
                 "GCC Runtime Library Exception 3.1 to GPL 3.0",
                 "GNU General Public License v3.0 w/GCC Runtime Library exception",
                 "GPLv3 + GCC Runtime Library Exception version 3.1",
-                "GPL 3.0 w/RTE"
+              "GPL 3.0 w/RTE",
+              "GPL-3 w/ GCC exception"
             ],
             "compatibility_as": "0BSD"
         },

--- a/var/licenses/BSL-1.0.json
+++ b/var/licenses/BSL-1.0.json
@@ -30,6 +30,7 @@
         "boost-1.0",
         "BOOST-1.0",
         "License :: OSI Approved :: Boost Software License 1.0 (BSL-1.0)",
-        "Boost Software License - Version 1.0 - August 17th, 2003"
+        "Boost Software License - Version 1.0 - August 17th, 2003",
+        "Boost License v1"
     ]
 }

--- a/var/licenses/GPL-2.0-only.json
+++ b/var/licenses/GPL-2.0-only.json
@@ -89,6 +89,7 @@
       "GPL 2",
       "GNU GPL v2.0",
       "General Public License v2.0",
-      "GPLv2 only"
+      "GPLv2 only",
+      "GNU General Public License-2.0-only"
     ]
 }

--- a/var/licenses/GPL-2.0-or-later.json
+++ b/var/licenses/GPL-2.0-or-later.json
@@ -59,6 +59,7 @@
         "License :: OSI Approved :: GNU General Public License v2 or later",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
       "GPLv2-or-later",
-      "GPLv2 or later"
+      "GPLv2 or later",
+      "GNU General Public License-2.0-or-later"
     ]
 }

--- a/var/licenses/GPL-3.0-only.json
+++ b/var/licenses/GPL-3.0-only.json
@@ -79,6 +79,7 @@
         "GNU GENERAL PUBLIC LICENSE V3",
       "the GNU General Public License version 3",
       "GNU General Public License 3",
-      "GPLv3 only"
+      "GPLv3 only",
+      "GNU General Public License-3.0-only"
     ]
 }

--- a/var/licenses/GPL-3.0-or-later.json
+++ b/var/licenses/GPL-3.0-or-later.json
@@ -56,7 +56,7 @@
         "gpl-3.0-plus",
         "License :: OSI Approved :: GNU General Public License v3 or later",
       "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-
-      "GPLv3 or later"      
+      "GPLv3 or later",
+      "GNU General Public License-3.0-or-later"
     ]
 }

--- a/var/licenses/MIT.json
+++ b/var/licenses/MIT.json
@@ -44,6 +44,7 @@
         "The MIT Licensse",
         "MIT/X",
         "Expat (MIT)",
-        "MIT / Expat"
+        "MIT / Expat",
+        "MIT License (MIT License)"
     ]
 }

--- a/var/licenses/MPL-2.0.json
+++ b/var/licenses/MPL-2.0.json
@@ -35,6 +35,7 @@
         "MPL_2.0",
         "MPL2",
         "Mozilla Public License v 2.0",
-        "Mozilla Public License 2.0 (MPL 2.0) (MPL-2.0)"
+      "Mozilla Public License 2.0 (MPL 2.0) (MPL-2.0)",
+      "MPL 2"
     ]
 }

--- a/var/licenses/Python-2.0.json
+++ b/var/licenses/Python-2.0.json
@@ -27,6 +27,8 @@
    "PSFL-v2",
    "PSFL-2.0",
    "PSF-2.0 (Python Software Foundation License 2.0)",
-   "PSF2"
+    "PSF2",
+    "Software Foundation License Version 2",
+    "Python Software Foundation License2"
   ]
 }

--- a/var/licenses/Python-2.0.json
+++ b/var/licenses/Python-2.0.json
@@ -26,6 +26,7 @@
    "PSF 2.0",
    "PSFL-v2",
    "PSFL-2.0",
-   "PSF-2.0 (Python Software Foundation License 2.0)"
+   "PSF-2.0 (Python Software Foundation License 2.0)",
+   "PSF2"
   ]
 }

--- a/var/licenses/Zlib.json
+++ b/var/licenses/Zlib.json
@@ -27,6 +27,8 @@
         "scancode:zlib",
         "scancode:d-zlib",
         "osi:Zlib",
-        "zlib-libpng"
+      "zlib-libpng",
+      "Zlib license",
+      "zlib license"
     ]
 }


### PR DESCRIPTION
# New aliases for
* BSL-1.0
* GPL-2.0-only
* GPL-2.0-or-later
* GPL-3.0-only
* GPL-3.0-or-later
* MIT
* MPL-2.0
* Python-2.0
* Python-2.0
* Zlib

# New ambiguos aliases for
* Python Software Foundation License

# New compound aliases for
* GPL-2.0-only WITH Linux-syscall-note
* GPL-3.0-only WITH GCC-exception-3.1
