### PR TITLE
Speed up lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Current support:
 |Type            | Number |
 |----------------|--------|
 |Licenses        | 184    |
-|Aliases         | 2550     |
+|Aliases         | 2549     |
 |Compatibilities | 23     |
 |Operators       | 14   |
 |Ambiguities     | 149 |

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 |Type            | Number |
 |----------------|--------|
 |Licenses        | 184    |
-|Aliases         | 2550     |
+|Aliases         | 2549     |
 |Compatibilities | 23     |
 |Operators       | 14   |
 |Ambiguities     | 149 |

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,6 +4,6 @@
 
 jsonschema
 PyYAML
-license_expression
+license_expression == 30.3.1
 osadl_matrix
 spdx_license_list

--- a/tests/python/test_speed.py
+++ b/tests/python/test_speed.py
@@ -1,0 +1,36 @@
+#!/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Before rewrite
+# -------------------
+# real    0m47,035s
+# user    0m47,018s
+# sys     0m0,013s
+
+# After rewrite
+# -------------------
+# real    0m0,465s
+# user    0m0,452s
+# sys     0m0,013s
+
+# so for consecutive calls, a call now takes 1% of what it took before
+
+
+from flame.license_db import FossLicenses
+fl = FossLicenses()
+
+
+
+for lic in [ "MIT", "BSD-3-Clause", "GPL-2.0-or-later" , "GPL-2.0-only" ]:
+    lic_obj = fl.license_complete(lic)
+    print(f'{lic}: ', end='')
+    for alias in lic_obj['aliases']:
+        expression = fl.expression_license(alias, update_dual=False)
+        assert lic == expression['identified_license']
+        print('.', end='')
+    print()
+        
+

--- a/var/licenses/Apache-2.0.json
+++ b/var/licenses/Apache-2.0.json
@@ -37,7 +37,6 @@
         "Apache Licence, version 2.0",
         "Apache-2.0 License",
         "Apache-2",
-        "Apache License  2.0",
         "Apache License v2.0",
         "Apache2",
         "Apache v2",


### PR DESCRIPTION
Pre-compile all regular expressions. This will speed things up significantly (after the first lookup). This will not impact the command line tool since it does only one lookup.


Testing with some lookups

## Before rewrite

```
real    0m47,035s
user    0m47,018s
sys     0m0,013s
```

## After rewrite

```
real    0m0,465s
user    0m0,452s
sys     0m0,013s
```