### PR TITLE
Add interactive shell mode

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,6 +48,7 @@ jobs:
         make check_license_schema
     - name: CLI check
       run: |
+        tests/shell/shell-test.sh
         flame -h
         flame license BSD3
         flame compat BSD3

--- a/devel/check-license-file.sh
+++ b/devel/check-license-file.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+#
+# Looks for unknown licenses in a file with license (expressions)
+#     check-license-file.sh <LICENSE-FILE>
+# 
+
+cat $1 | while read LICENSE
+do
+    printf "unknown\n$LICENSE\n" 
+done | ./devel/flame shell -s | grep -v Unknown

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -148,9 +148,9 @@ def get_parser():
         'shell',
         help='Start interactive shell')
     parser_sh.add_argument('-s', '--silent',
-                        action='store_true',
-                        help='minimize output',
-                        default=False)
+                           action='store_true',
+                           help='minimize output',
+                           default=False)
     parser_sh.set_defaults(which='shell', func=interactive_shell)
 
     # unknown

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -144,10 +144,14 @@ def get_parser():
     parser_os.set_defaults(which='operators', func=operators)
 
     # shell
-    parser_os = subparsers.add_parser(
+    parser_sh = subparsers.add_parser(
         'shell',
         help='Start interactive shell')
-    parser_os.set_defaults(which='shell', func=interactive_shell)
+    parser_sh.add_argument('-s', '--silent',
+                        action='store_true',
+                        help='minimize output',
+                        default=False)
+    parser_sh.set_defaults(which='shell', func=interactive_shell)
 
     # unknown
     parser_u = subparsers.add_parser(
@@ -158,7 +162,7 @@ def get_parser():
     return parser
 
 def interactive_shell(fl, formatter, args):
-    FlameShell().cmdloop()
+    FlameShell(not args.silent).cmdloop()
     return "", None
 
 def parse():

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -16,6 +16,7 @@ import flame.config
 from flame.format import OUTPUT_FORMATS
 from flame.format import OutputFormatterFactory
 from flame.exception import FlameException
+from flame.flame_shell import FlameShell
 
 def get_parser():
 
@@ -142,6 +143,12 @@ def get_parser():
         'operators', help='Display all operators')
     parser_os.set_defaults(which='operators', func=operators)
 
+    # shell
+    parser_os = subparsers.add_parser(
+        'shell',
+        help='Start interactive shell')
+    parser_os.set_defaults(which='shell', func=interactive_shell)
+
     # unknown
     parser_u = subparsers.add_parser(
         'unknown', help='Show the unknown licenses for a license expression. Intended for foss-licenses developers.')
@@ -149,6 +156,9 @@ def get_parser():
     parser_u.add_argument('license', type=str, nargs='+', help='license expression to fix')
 
     return parser
+
+def interactive_shell(fl, formatter, args):
+    return FlameShell().cmdloop()
 
 def parse():
 

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -158,7 +158,8 @@ def get_parser():
     return parser
 
 def interactive_shell(fl, formatter, args):
-    return FlameShell().cmdloop()
+    FlameShell().cmdloop()
+    return "", None
 
 def parse():
 

--- a/python/flame/flame_shell.py
+++ b/python/flame/flame_shell.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import cmd
+import sys
+
+from flame.license_db import FossLicenses
+from flame.format import OutputFormatterFactory
+
+
+class FlameShell(cmd.Cmd):
+    intro = 'Welcome to the Flame shell. Type help or ? to list commands.\n'
+    prompt = '>>> '
+    file = None
+
+    def __init__(self, verbose=False):
+        cmd.Cmd.__init__(self)
+        self.verbose_mode = verbose
+        self.formatter = None
+        self.flame = FossLicenses()
+
+    def output(self, string, end="\n"):
+        print(string, end=end)
+
+    def verbose(self, string, end="\n"):
+        if self.verbose_mode:
+            print(string, end=end)
+
+    def __handle_error(self, error):
+        print(str(error))
+
+    def do_exit(self, arg):
+        """Exit the interactive shell"""
+        return True
+
+    def do_EOF(self, args):
+        """Sending EOF (e.g. Control-d) will exit the interactive shell"""
+        return True
+
+    def emptyline(self):
+        return self.do_text(None)
+
+    def __read_license(self):
+        if self.verbose_mode:
+            print("Enter license name: ", end="")
+        try:
+            line = input()
+            return line
+        except EOFError:
+            pass
+
+    
+    def do_unknown(self, arg):
+        """."""
+        license_name = self.__read_license()
+        try:
+            unknowns = self.flame.unknown_symbols([license_name])
+            #print(str(unknowns[0]))
+        except Exception as e:
+            print("Unknown: " + str(e))
+
+    def do_license(self, arg):
+        """."""
+        license_name = self.__read_license()
+        try:
+            expression = self.flame.expression_license(license_name, validations=None, update_dual=False)
+            res, err = OutputFormatterFactory.formatter("text").format_expression(expression, self.verbose)
+            print(str(res))
+            
+        except Exception as e:
+            print(str(e))
+
+    def do_simplify(self, arg):
+        """."""
+        license_name = self.__read_license()
+        try:
+            expression = self.flame.expression_license(license_name, validations=None, update_dual=False)
+            simplified = self.flame.simplify([expression['identified_license']])
+            res, err = OutputFormatterFactory.formatter("text").format_licenses([str(simplified)], self.verbose)
+            print(str(res))
+            
+        except Exception as e:
+            print(str(e))
+
+    def do_verbose(self, arg):
+        """Make the interaction more verbose."""
+        self.verbose_mode = True
+        prompt = ''
+        
+    def do_silent(self, arg):
+        """Make the interaction less verbose (default)."""
+        self.verbose_mode = False
+        self.prompt = ''
+
+    def __output_result(self, result):
+        if self.verbose_mode:
+            if not self.formatter:
+                self.formatter = OutputFormatterFactory.formatter("text")
+            out, err = self.formatter.format_license(result)
+            if err:
+                print("error" + err, file=sys.stderr)
+            print(out)
+        else:
+            print(str(result['normalized']))
+
+
+if __name__ == '__main__':
+    FlameShell().cmdloop()

--- a/python/flame/flame_shell.py
+++ b/python/flame/flame_shell.py
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+#
+# Interactive flame shell
+#
+
+
 import cmd
 import sys
 
@@ -10,13 +15,17 @@ from flame.format import OutputFormatterFactory
 
 
 class FlameShell(cmd.Cmd):
-    intro = 'Welcome to the Flame shell. Type help or ? to list commands.\n'
+#    intro = 'Welcome to the Flame shell. Type help or ? to list commands.\n'
     prompt = '>>> '
     file = None
 
     def __init__(self, verbose=False):
         cmd.Cmd.__init__(self)
-        self.verbose_mode = verbose
+        if verbose:
+            self.do_verbose(None)
+            self.output('Welcome to the Flame shell. Type help or ? to list commands.\n')
+        else:
+            self.do_silent(None)
         self.formatter = None
         self.flame = FossLicenses()
 
@@ -39,7 +48,7 @@ class FlameShell(cmd.Cmd):
         return True
 
     def emptyline(self):
-        return self.do_text(None)
+        return ""
 
     def __read_license(self):
         if self.verbose_mode:
@@ -86,7 +95,7 @@ class FlameShell(cmd.Cmd):
     def do_verbose(self, arg):
         """Make the interaction more verbose."""
         self.verbose_mode = True
-        prompt = ''
+        prompt = '>>> '
         
     def do_silent(self, arg):
         """Make the interaction less verbose (default)."""

--- a/python/flame/flame_shell.py
+++ b/python/flame/flame_shell.py
@@ -61,7 +61,7 @@ class FlameShell(cmd.Cmd):
             pass
 
     def do_unknown(self, arg):
-        """."""
+        """Output the unknown licenses in the supplied license expression."""
         license_name = self.__read_license()
         try:
             self.flame.unknown_symbols([license_name])
@@ -69,7 +69,7 @@ class FlameShell(cmd.Cmd):
             print("Unknown: " + str(e))
 
     def do_license(self, arg):
-        """."""
+        """Identify the SPDX license identifiers (if any) for the license expression."""
         license_name = self.__read_license()
         try:
             expression = self.flame.expression_license(license_name, validations=None, update_dual=False)
@@ -80,7 +80,7 @@ class FlameShell(cmd.Cmd):
             print(str(e))
 
     def do_simplify(self, arg):
-        """."""
+        """Simplify the supplied license expression."""
         license_name = self.__read_license()
         try:
             expression = self.flame.expression_license(license_name, validations=None, update_dual=False)

--- a/python/flame/flame_shell.py
+++ b/python/flame/flame_shell.py
@@ -15,7 +15,8 @@ from flame.format import OutputFormatterFactory
 
 
 class FlameShell(cmd.Cmd):
-#    intro = 'Welcome to the Flame shell. Type help or ? to list commands.\n'
+    intro = ''
+    # Welcome to the Flame shell. Type help or ? to list commands.\n'
     prompt = '>>> '
     file = None
 
@@ -59,13 +60,11 @@ class FlameShell(cmd.Cmd):
         except EOFError:
             pass
 
-    
     def do_unknown(self, arg):
         """."""
         license_name = self.__read_license()
         try:
-            unknowns = self.flame.unknown_symbols([license_name])
-            #print(str(unknowns[0]))
+            self.flame.unknown_symbols([license_name])
         except Exception as e:
             print("Unknown: " + str(e))
 
@@ -76,7 +75,7 @@ class FlameShell(cmd.Cmd):
             expression = self.flame.expression_license(license_name, validations=None, update_dual=False)
             res, err = OutputFormatterFactory.formatter("text").format_expression(expression, self.verbose)
             print(str(res))
-            
+
         except Exception as e:
             print(str(e))
 
@@ -88,15 +87,15 @@ class FlameShell(cmd.Cmd):
             simplified = self.flame.simplify([expression['identified_license']])
             res, err = OutputFormatterFactory.formatter("text").format_licenses([str(simplified)], self.verbose)
             print(str(res))
-            
+
         except Exception as e:
             print(str(e))
 
     def do_verbose(self, arg):
         """Make the interaction more verbose."""
         self.verbose_mode = True
-        prompt = '>>> '
-        
+        self.prompt = '>>> '
+
     def do_silent(self, arg):
         """Make the interaction less verbose (default)."""
         self.verbose_mode = False

--- a/tests/shell/shell-test.sh
+++ b/tests/shell/shell-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+exec_shell()
+{
+    COMMAND="$1"
+    SHELL_ARGS="$2"
+    printf "$COMMAND\nexit\n" | ./devel/flame shell $SHELL_ARGS
+}
+
+test_shell()
+{
+    COMMAND="$1"
+    EXPECTED="$2"
+    SHELL_ARGS="$3"
+
+    echo -n "$COMMAND: "
+    
+    ACTUAL=$(exec_shell "$COMMAND" "$SHELL_ARGS")
+
+    if [ "$ACTUAL" != "$EXPECTED" ]
+    then
+        echo
+        echo "ERROR"
+        echo "  command: $COMMAND"
+        echo "  exepcted: $EXPECTED"
+        echo "  actual:   $ACTUAL"
+    fi
+
+    echo "OK"
+}
+
+test_shell_silent()
+{
+    test_shell "$1" "$2" "-s"
+}
+
+test_shell_silent "license\nmit" "MIT"
+test_shell_silent "license\nmit and mit" "MIT AND MIT"
+test_shell_silent "simplify\nmit and mit" "MIT"

--- a/tests/shell/shell-test.sh
+++ b/tests/shell/shell-test.sh
@@ -28,6 +28,7 @@ test_shell()
         echo "  command: $COMMAND"
         echo "  exepcted: $EXPECTED"
         echo "  actual:   $ACTUAL"
+        exit 1
     fi
 
     echo "OK"
@@ -38,6 +39,15 @@ test_shell_silent()
     test_shell "$1" "$2" "-s"
 }
 
+# test command: license
 test_shell_silent "license\nmit" "MIT"
 test_shell_silent "license\nmit and mit" "MIT AND MIT"
+
+# test command: simplify
 test_shell_silent "simplify\nmit and mit" "MIT"
+test_shell_silent "simplify\nGPL-2.0-only" "GPL-2.0-only"
+
+# test command: unknown 
+test_shell_silent "unknown\nsomeweirdlicense" "Unknown: Unknown symbols identified.
+someweirdlicense"
+test_shell_silent "unknown\nmit" ""


### PR DESCRIPTION
When looking up many licenses in a row from  a script, you can use interactive mode and pipe commands (see below) to avoid initializing the tool for every call.

Example:
```
$ printf "license\nmit\nlicense\nBSD3 AND mit and MIT\n" | ./devel/flame shell --silent
MIT
BSD-3-Clause AND MIT AND MIT
```

