### PR TITLE
Add licenses bulk 027

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Current support:
 
 |Type            | Number |
 |----------------|--------|
-|Licenses        | 195    |
-|Aliases         | 2696   |
+|Licenses        | 201    |
+|Aliases         | 2805   |
 |Compatibilities | 23     |
 |Operators       | 14     |
-|Ambiguities     | 143    |
-|Compounds       | 38     |
+|Ambiguities     | 159    |
+|Compounds       | 46     |
 
 # About
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,9 @@
 
 |Type            | Number |
 |----------------|--------|
-|Licenses        | 195    |
-|Aliases         | 2696   |
+|Licenses        | 201    |
+|Aliases         | 2805   |
 |Compatibilities | 23     |
 |Operators       | 14     |
-|Ambiguities     | 143    |
-|Compounds       | 38     |
+|Ambiguities     | 159    |
+|Compounds       | 46     |

--- a/devel/check-license-file.sh
+++ b/devel/check-license-file.sh
@@ -9,7 +9,8 @@
 #     check-license-file.sh <LICENSE-FILE>
 # 
 
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})/../
 cat $1 | while read LICENSE
 do
     printf "unknown\n$LICENSE\n" 
-done | ./devel/flame shell -s | grep -v Unknown
+done | ${SCRIPT_DIR}/devel/flame shell -s | grep -v Unknown

--- a/devel/flame
+++ b/devel/flame
@@ -4,4 +4,5 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-PYTHONPATH=./python python/flame/__main__.py $*
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})/../
+PYTHONPATH=${SCRIPT_DIR}/python ${SCRIPT_DIR}/python/flame/__main__.py $*

--- a/tests/shell/sanity-check.sh
+++ b/tests/shell/sanity-check.sh
@@ -171,10 +171,10 @@ check_presence Bootloader-exception " -i bootloader" ""
 check_presence BSL-1.0                            " -e BSL-1 -e BSL1 -e 1 " " -i -e original "
 
 
+check_presence LicenseRef-scancode-khronos " -i -e khronos" ""
 check_presence LicenseRef-scancode-openssl-exception-lgpl " -i -e openssl" ""
 check_presence LicenseRef-scancode-openssl-exception-gpl-2.0-plus " -i -e openssl" ""
 check_presence LicenseRef-scancode-openssl-exception-lgpl2.0plus " -i -e openssl" ""
-
 check_presence LicenseRef-scancode-boost-original " -i -e original "        " -e BSL-1 -e BSL1 -e 1 "  
 check_presence LicenseRef-scancode-ssleay " -i -e leay "        " -e openssl"  
 

--- a/tests/shell/sanity-check.sh
+++ b/tests/shell/sanity-check.sh
@@ -89,13 +89,17 @@ check_presence()
     if [ "$PRESENT" != "" ]
     then
         echo "FAIL"
-        echo " * cause: Not present in $FILE"
+        echo " * cause: Not present ($PRESENT) in $FILE"
         echo " --------------------------"
         echo "Should be present: $REG_EXP_PRESENCE"
+        echo " --------------------------"
+        echo "Try yourself: "
+        echo "              cat $FILE | jq  -r .aliases[] | grep -v \"$REG_EXP_PRESENCE\""
         echo " --------------------------"
         RET=$(( $RET + 1 ))
         _RET="FAIL"
         LICENSE_ERRORS="$LICENSE_ERRORS  $REG_EXP_PRESENCE not present in $FILE"
+        exit
     fi
 
     # check unpresence
@@ -147,6 +151,8 @@ check_presence AFL-2.0 " -e 2.0 " "-e 1 -e 2.1 -e 3"
 check_presence AFL-2.1 " -e 2.1 " "-e 1. -e 2.0 -e 0  -e 3"
 check_presence AFL-3.0 " -e 3 " "-e 1 -e 2 "
 
+check_presence AGPL-1.0-only     " -i -e 1 -e affero" " -e '1 ' -e 2 -e later -e plus -e + -e library -e lesser "
+check_presence AGPL-1.0-or-later     " -i -e 1 -e affero" " -e '1 '  -e library -e lesser "
 check_presence AGPL-3.0-only     " -i -e 3 -e affero" " -e '1 ' -e 2 -e later -e plus -e + -e library -e lesser "
 check_presence AGPL-3.0-or-later " -e 3 -e later -e +" " -e '1 ' -e 2  -e library -e lesser "
 
@@ -180,10 +186,11 @@ check_presence LicenseRef-scancode-ssleay " -i -e leay "        " -e openssl"
 
 check_presence 0BSD "$ZERO_BSD_PRESENT" "$BSD3_PRESENT $BSD2_PRESENT "
 check_presence BSD-1-Clause " -i BSD" " -e 2 -e 3 -e 4 "
-check_presence BSD-2-Clause "$BSD2_PRESENT" "$ZERO_BSD_PRESENT $BSD3_PRESENT "
+check_presence BSD-2-Clause "$BSD2_PRESENT" " -e 3 "
 check_presence BSD-2-Clause-Patent "$BSD2_PATENT_PRESENT" "$ZERO_BSD_PRESENT $BSD3_PRESENT "
 check_presence BSD-2-Clause-Views " -i -e view"  " -e 0 -e 1 -e 3 -e 4"
 check_presence BSD-3-Clause "$BSD3_PRESENT" "$ZERO_BSD_PRESENT  -i -e two -e simplified -e freebsd "
+check_presence BSD-3-Clause-Attribution " -i -e ack -e attribution" " -e 0 -e 1 -e 2 -e 4"
 check_presence BSD-3-Clause-Clear " -i -e clear" " -e 0 -e 1 -e 2 -e 4"
 check_presence BSD-3-Clause-Modification " -i -e modification -e repoze " " -e 0 -e 1 -e 2 -e 4"
 check_presence BSD-3-Clause-No-Nuclear-Warranty " -i -e nuclear" " -e 0 -e 1 -e 2 -e 4"
@@ -331,6 +338,7 @@ check_presence Plexus " -i -e plexus -e classworlds " ""
 check_presence PostgreSQL " -i -e postgresql " ""
 check_presence Python-2.0.1 " -i -e Python " ""
 
+check_presence romic-exception " -i -e romic " ""
 check_presence RSA-MD " -i -e RSA " ""
 check_presence RSCPL " -i -e RSCPL -e Ricoh " ""
 
@@ -371,7 +379,7 @@ check_presence xpp " -i -e xpp -e indiana " ""
 check_presence LicenseRef-scancode-xfree86-1.0 " -i -e 1.0 " " -e  X/MIT -e 1.1 " 
 check_presence XFree86-1.1 " -i -e 1.1 " " -e  X/MIT -e 1.0 " 
 
-check_presence Zlib " -i -e libz -e zlib" " -i bsd "
+check_presence Zlib " -i -e libz -e zlib -e z-lib" " -i bsd "
 check_presence ZPL-1.1 " -e 1.1" " -e 2"
 check_presence ZPL-2.0 " -e 2.0" " -e 1 -e 2.1"
 check_presence ZPL-2.1 " -e 2.1" " -e 1.1 -e 2.0"

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -39,7 +39,8 @@
               "OSI Approved Apache Software License",
               "apache",
               "OSI-Approved-::-Apache-Software-License",
-              "LICENSE-APACHE"
+              "LICENSE-APACHE",
+              "Apache other"
             ],
             "problem": "This license has different version (1.0, 1.1, and 2.0). Without a version number it is not possible to determine which of the versions is meant."
         },
@@ -92,7 +93,11 @@
                 "BSD license",
                 "License :: OSI Approved :: BSD License",
               "BSD licensed code",
-              "BSD Software License"
+              "BSD Software License",
+              "BSD_License",
+              "BSD_License_",
+              "BSD like",
+              "BSD-LIKE"
             ],
             "problem": "There are a couple of variants or versions of the BSD license (0BSD, BSD-1-Clause, BSD-2-Clause, BSD-3-Clause and BSD-4-Clause). Without the version/variant of the license it is not possible to determine which of the versions is meant."
         },
@@ -187,7 +192,7 @@
                 "GNU GENERAL PUBLIC LICENSE",
                 "License :: OSI Approved :: GNU General Public License",
                 "License :: OSI Approved :: GNU General Public License (GPL)",
-                "GNU General Public License (GPL)",
+              "GNU General Public License (GPL)",
               "GNU-GPL",
               "GPL license"
             ],
@@ -208,7 +213,8 @@
             "GNU Library",
             "GNU Library or GNU Lesser General Public License",
             "GNU Lesser General Public License v1.0",
-            "LGPL license"
+            "LGPL license",
+            "GNU Lesser Public License"
           ],
           "problem": "This license has different versions (2.0, 2.1 and 3.0). Without a version number it is not possible to determine which of the versions is meant."
         },
@@ -222,7 +228,9 @@
                 "MIT Like",
                 "MIT-style License.",
                 "MIT-license",
-                "MIT-Licences"
+              "MIT-Licences",
+              "MIT-like License",
+              "MIT Style License"
             ],
             "problem": "This is not a license identifier. It is most likely a license similar to MIT, but without more information no assumptions can be made."
         },

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -206,7 +206,8 @@
             "GNU Library/LGPL",
             "GNU Library",
             "GNU Library or GNU Lesser General Public License",
-            "GNU Lesser General Public License v1.0"
+            "GNU Lesser General Public License v1.0",
+            "LGPL license"
           ],
           "problem": "This license has different versions (2.0, 2.1 and 3.0). Without a version number it is not possible to determine which of the versions is meant."
         },
@@ -280,7 +281,9 @@
               "The Python Software Foundation License",
               "PSF-License",
               "psf-license",
-              "PSF LICENSE"
+              "PSF LICENSE",
+              "Python Open Source GPL Compatible License Agreement",
+              "Software Foundation License"
             ],
             "problem": "This license has different versions (2.0 and 2.0.1). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -15,7 +15,8 @@
         },
         "GNU Affero General Public License": {
             "aliases": [
-                "AGPL"
+              "AGPL",
+              " Affero General Public License"
             ],
             "problem": "This license has different versions (1.0, 2.0 and 3.0) and different names (version 1.0 does not have GNU in the name). Without a version number it is not possible to determine which of the versions is meant."
         },

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -37,7 +37,8 @@
                 "License :: OSI Approved :: Apache Software License",
               "OSI Approved Apache Software License",
               "apache",
-              "OSI-Approved-::-Apache-Software-License"
+              "OSI-Approved-::-Apache-Software-License",
+              "LICENSE-APACHE"
             ],
             "problem": "This license has different version (1.0, 1.1, and 2.0). Without a version number it is not possible to determine which of the versions is meant."
         },
@@ -276,7 +277,9 @@
                 "Python Software Foundation",
               "Python Software Foundation License (PSFL)",
               "The Python Software Foundation License",
-              "PSF-License"
+              "PSF-License",
+              "psf-license",
+              "PSF LICENSE"
             ],
             "problem": "This license has different versions (2.0 and 2.0.1). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -229,7 +229,8 @@
                 "MPL",
                 "MPL-1",
                 "MPLv1",
-                "Mozilla-permissive"
+              "Mozilla-permissive",
+              "Mozilla"
             ],
             "problem": "This license has different version (1.0, 1.1 and 2.0). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },

--- a/var/compounds.json
+++ b/var/compounds.json
@@ -4,6 +4,13 @@
         "comment": ""
     },
     "compounds": [
+      {
+        "spdxid": "AGPL 3.0 WITH romic-exception",
+        "aliases": [
+          "linking-exception-agpl-3.0",
+          "AGPL-3.0-only WITH romic-exception"
+        ]
+      },
         {
             "spdxid": "Apache-2.0 WITH LLVM-exception",
             "aliases": [

--- a/var/compounds.json
+++ b/var/compounds.json
@@ -39,7 +39,8 @@
                 "GPL v2.0 w/ CPE",
               "GPL2 w CPE",
               "GPL-2.0-only WITH the Classpath Exception",
-              "GPL-2.0-only WITH the classpath exception"
+              "GPL-2.0-only WITH the classpath exception",
+              "GPLv2+CE"
             ]
         },
         {
@@ -97,7 +98,12 @@
                 "GNU General Public License v3.0 w/GCC Runtime Library exception",
                 "GPLv3 + GCC Runtime Library Exception version 3.1",
               "GPL 3.0 w/RTE",
-              "GPL-3 w/ GCC exception"
+              "GPL-3 w/ GCC exception",
+              "GPL-3.0-only WITH GCC exception",
+              "GPL-3.0-only WITH GCC Runtime Library exception",
+              "GPL-3.0+-with-GCC-exception",
+              "GPL-2.0-only WITH GCC exception",
+              "GPL-2.0-only WITH GCC Runtime Library exception"
             ],
             "compatibility_as": "0BSD"
         },

--- a/var/licenses/0BSD.json
+++ b/var/licenses/0BSD.json
@@ -24,6 +24,7 @@
     "License :: OSI Approved :: Zero-Clause BSD (0BSD)",
     "BSD 0C",
     "Free Public License 1.0.0",
-    "free-public-license-1-0-0"
+    "free-public-license-1-0-0",
+    "bsd-0-clause"
   ]
 }

--- a/var/licenses/AGPL-1.0-only.LICENSE
+++ b/var/licenses/AGPL-1.0-only.LICENSE
@@ -1,0 +1,273 @@
+AFFERO GENERAL PUBLIC LICENSE
+
+Version 1, March 2002
+
+Copyright © 2002 Affero Inc.
+510 Third Street - Suite 225, San Francisco, CA 94107, USA
+
+This license is a modified version of the GNU General Public License copyright
+(C) 1989, 1991 Free Software Foundation, Inc. made with their permission.
+Section 2(d) has been added to cover use of software over a computer network.
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the Affero General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users. This Public License applies to most of
+Affero's software and to any other program whose authors commit to using it.
+(Some other Affero software is covered by the GNU Library General Public License
+instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. This
+General Public License is designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you can
+do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights. These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a
+fee, you must give the recipients all the rights that you have. You must make
+sure that they, too, receive or can get the source code. And you must show them
+these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer
+you this license which gives you legal permission to copy, distribute and/or
+modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software. If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced by
+others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish
+to avoid the danger that redistributors of a free program will individually
+obtain patent licenses, in effect making the program proprietary. To prevent
+this, we have made it clear that any patent must be licensed for everyone's free
+use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this Affero General Public License. The "Program", below, refers to any such
+program or work, and a "work based on the Program" means either the Program or
+any derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language. (Hereinafter, translation is included without
+limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope. The act of running the Program is not
+restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as
+you receive it, in any medium, provided that you conspicuously and appropriately
+publish on each copy an appropriate copyright notice and disclaimer of warranty;
+keep intact all the notices that refer to this License and to the absence of any
+warranty; and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at
+your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus
+forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all of
+these conditions:
+
+* a) You must cause the modified files to carry prominent notices stating that
+you changed the files and the date of any change.
+
+* b) You must cause any work that you distribute or publish, that in whole or in
+part contains or is derived from the Program or any part thereof, to be licensed
+as a whole at no charge to all third parties under the terms of this License.
+
+* c) If the modified program normally reads commands interactively when run, you
+must cause it, when started running for such interactive use in the most
+ordinary way, to print or display an announcement including an appropriate
+copyright notice and a notice that there is no warranty (or else, saying that
+you provide a warranty) and that users may redistribute the program under these
+conditions, and telling the user how to view a copy of this License. (Exception:
+if the Program itself is interactive but does not normally print such an
+announcement, your work based on the Program is not required to print an
+announcement.)
+
+* d) If the Program as you received it is intended to interact with users
+through a computer network and if, in the version you received, any user
+interacting with the Program was given the opportunity to request transmission
+to that user of the Program's complete source code, you must not remove that
+facility from your modified version of the Program or work based on the Program,
+and must offer an equivalent opportunity for all users interacting with your
+Program through a computer network to request immediate transmission by HTTP of
+the complete source code of your modified version or other derivative work.
+
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works. But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the entire whole,
+and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on the
+Program.
+
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section
+2) in object code or executable form under the terms of Sections 1 and 2 above
+provided that you also do one of the following:
+
+* a) Accompany it with the complete corresponding machine-readable source code,
+which must be distributed under the terms of Sections 1 and 2 above on a medium
+customarily used for software interchange; or,
+
+* b) Accompany it with a written offer, valid for at least three years, to give
+any third party, for a charge no more than your cost of physically performing
+source distribution, a complete machine-readable copy of the corresponding
+source code, to be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange; or,
+
+* c) Accompany it with the information you received as to the offer to
+distribute corresponding source code. (This alternative is allowed only for
+noncommercial distribution and only if you received the program in object code
+or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it. For an executable work, complete source code means all the
+source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable. However, as a special exception, the source code distributed
+need not include anything that is normally distributed (in either source or
+binary form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component itself
+accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source code
+from the same place counts as distribution of the source code, even though third
+parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License. Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License. However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Program
+or its derivative works. These actions are prohibited by law if you do not
+accept this License. Therefore, by modifying or distributing the Program (or any
+work based on the Program), you indicate your acceptance of this License to do
+so, and all its terms and conditions for copying, distributing or modifying the
+Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor to
+copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of the
+rights granted herein. You are not responsible for enforcing compliance by third
+parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement
+or for any other reason (not limited to patent issues), conditions are imposed
+on you (whether by court order, agreement or otherwise) that contradict the
+conditions of this License, they do not excuse you from the conditions of this
+License. If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations, then as a
+consequence you may not distribute the Program at all. For example, if a patent
+license would not permit royalty-free redistribution of the Program by all those
+who receive copies directly or indirectly through you, then the only way you
+could satisfy both it and this License would be to refrain entirely from
+distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and the
+section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices. Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original copyright
+holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded. In such
+case, this License incorporates the limitation as if written in the body of this
+License.
+
+9. Affero Inc. may publish revised and/or new versions of the Affero General
+Public License from time to time. Such new versions will be similar in spirit to
+the present version, but may differ in detail to address new problems or
+concerns.
+
+Each version is given a distinguishing version number. If the Program specifies
+a version number of this License which applies to it and "any later version",
+you have the option of following the terms and conditions either of that version
+or of any later version published by Affero, Inc. If the Program does not
+specify a version number of this License, you may choose any version ever
+published by Affero, Inc.
+
+You may also choose to redistribute modified versions of this program under any
+version of the Free Software Foundation's GNU General Public License version 3
+or higher, so long as that version of the GNU GPL includes terms and conditions
+substantially equivalent to those of this license.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission. For software which is copyrighted by Affero, Inc., write to us; we
+sometimes make exceptions for this. Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and of
+promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE
+PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED
+IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS
+IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE
+PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL,
+SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY
+TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER
+PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.

--- a/var/licenses/AGPL-1.0-only.json
+++ b/var/licenses/AGPL-1.0-only.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
+    "comment": ""
+  },
+  "name": "Affero General Public License 1.0",
+  "scancode_key": "agpl-1.0",
+  "spdxid": "AGPL-1.0-only",
+  "aliases": [
+    "Affero General Public License 1.0",
+    "Affero General Public License (v. 1)",
+    "Affero General Public License v1.0 only",
+    "AGPL 1.0",
+    "AGPL-1.0-only",
+    "scancode://agpl-1.0",
+    "Affero General Public License",
+    "Affero General Public License v1.0",
+    "AFFERO GENERAL PUBLIC LICENSE Version 1",
+    "AGPL-1.0",
+    "AGPLv1",
+    "scancode:agpl-1.0"
+  ]
+}

--- a/var/licenses/AGPL-1.0-or-later.LICENSE
+++ b/var/licenses/AGPL-1.0-or-later.LICENSE
@@ -1,0 +1,283 @@
+This is free software; you can redistribute it and/or modify
+it under the terms of the AFFERO GENERAL PUBLIC LICENSE as published by
+Affero Inc; either version 1, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+AFFERO GENERAL PUBLIC LICENSE for more details.
+
+
+AFFERO GENERAL PUBLIC LICENSE
+
+Version 1, March 2002
+
+Copyright © 2002 Affero Inc.
+510 Third Street - Suite 225, San Francisco, CA 94107, USA
+
+This license is a modified version of the GNU General Public License copyright
+(C) 1989, 1991 Free Software Foundation, Inc. made with their permission.
+Section 2(d) has been added to cover use of software over a computer network.
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the Affero General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users. This Public License applies to most of
+Affero's software and to any other program whose authors commit to using it.
+(Some other Affero software is covered by the GNU Library General Public License
+instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. This
+General Public License is designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you can
+do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights. These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a
+fee, you must give the recipients all the rights that you have. You must make
+sure that they, too, receive or can get the source code. And you must show them
+these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer
+you this license which gives you legal permission to copy, distribute and/or
+modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software. If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced by
+others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish
+to avoid the danger that redistributors of a free program will individually
+obtain patent licenses, in effect making the program proprietary. To prevent
+this, we have made it clear that any patent must be licensed for everyone's free
+use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this Affero General Public License. The "Program", below, refers to any such
+program or work, and a "work based on the Program" means either the Program or
+any derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language. (Hereinafter, translation is included without
+limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope. The act of running the Program is not
+restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as
+you receive it, in any medium, provided that you conspicuously and appropriately
+publish on each copy an appropriate copyright notice and disclaimer of warranty;
+keep intact all the notices that refer to this License and to the absence of any
+warranty; and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at
+your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus
+forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all of
+these conditions:
+
+* a) You must cause the modified files to carry prominent notices stating that
+you changed the files and the date of any change.
+
+* b) You must cause any work that you distribute or publish, that in whole or in
+part contains or is derived from the Program or any part thereof, to be licensed
+as a whole at no charge to all third parties under the terms of this License.
+
+* c) If the modified program normally reads commands interactively when run, you
+must cause it, when started running for such interactive use in the most
+ordinary way, to print or display an announcement including an appropriate
+copyright notice and a notice that there is no warranty (or else, saying that
+you provide a warranty) and that users may redistribute the program under these
+conditions, and telling the user how to view a copy of this License. (Exception:
+if the Program itself is interactive but does not normally print such an
+announcement, your work based on the Program is not required to print an
+announcement.)
+
+* d) If the Program as you received it is intended to interact with users
+through a computer network and if, in the version you received, any user
+interacting with the Program was given the opportunity to request transmission
+to that user of the Program's complete source code, you must not remove that
+facility from your modified version of the Program or work based on the Program,
+and must offer an equivalent opportunity for all users interacting with your
+Program through a computer network to request immediate transmission by HTTP of
+the complete source code of your modified version or other derivative work.
+
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works. But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the entire whole,
+and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on the
+Program.
+
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section
+2) in object code or executable form under the terms of Sections 1 and 2 above
+provided that you also do one of the following:
+
+* a) Accompany it with the complete corresponding machine-readable source code,
+which must be distributed under the terms of Sections 1 and 2 above on a medium
+customarily used for software interchange; or,
+
+* b) Accompany it with a written offer, valid for at least three years, to give
+any third party, for a charge no more than your cost of physically performing
+source distribution, a complete machine-readable copy of the corresponding
+source code, to be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange; or,
+
+* c) Accompany it with the information you received as to the offer to
+distribute corresponding source code. (This alternative is allowed only for
+noncommercial distribution and only if you received the program in object code
+or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it. For an executable work, complete source code means all the
+source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable. However, as a special exception, the source code distributed
+need not include anything that is normally distributed (in either source or
+binary form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component itself
+accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source code
+from the same place counts as distribution of the source code, even though third
+parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License. Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License. However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Program
+or its derivative works. These actions are prohibited by law if you do not
+accept this License. Therefore, by modifying or distributing the Program (or any
+work based on the Program), you indicate your acceptance of this License to do
+so, and all its terms and conditions for copying, distributing or modifying the
+Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor to
+copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of the
+rights granted herein. You are not responsible for enforcing compliance by third
+parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement
+or for any other reason (not limited to patent issues), conditions are imposed
+on you (whether by court order, agreement or otherwise) that contradict the
+conditions of this License, they do not excuse you from the conditions of this
+License. If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations, then as a
+consequence you may not distribute the Program at all. For example, if a patent
+license would not permit royalty-free redistribution of the Program by all those
+who receive copies directly or indirectly through you, then the only way you
+could satisfy both it and this License would be to refrain entirely from
+distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and the
+section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices. Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original copyright
+holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded. In such
+case, this License incorporates the limitation as if written in the body of this
+License.
+
+9. Affero Inc. may publish revised and/or new versions of the Affero General
+Public License from time to time. Such new versions will be similar in spirit to
+the present version, but may differ in detail to address new problems or
+concerns.
+
+Each version is given a distinguishing version number. If the Program specifies
+a version number of this License which applies to it and "any later version",
+you have the option of following the terms and conditions either of that version
+or of any later version published by Affero, Inc. If the Program does not
+specify a version number of this License, you may choose any version ever
+published by Affero, Inc.
+
+You may also choose to redistribute modified versions of this program under any
+version of the Free Software Foundation's GNU General Public License version 3
+or higher, so long as that version of the GNU GPL includes terms and conditions
+substantially equivalent to those of this license.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission. For software which is copyrighted by Affero, Inc., write to us; we
+sometimes make exceptions for this. Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and of
+promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE
+PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED
+IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS
+IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE
+PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL,
+SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY
+TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER
+PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.

--- a/var/licenses/AGPL-1.0-or-later.json
+++ b/var/licenses/AGPL-1.0-or-later.json
@@ -1,0 +1,19 @@
+{
+"meta": {
+    "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
+    "comment": ""
+  },
+  "name": "Affero General Public License 1.0 or later",
+  "scancode_key": "agpl-1.0-plus",
+  "spdxid": "AGPL-1.0-or-later",
+  "aliases": [
+   "Affero General Public License 1.0 or later",
+   "Affero General Public License v1.0 or later",
+   "AGPL-1.0+",
+   "AGPL 1.0 or later",
+   "AGPL-1.0-or-later",
+   "scancode://agpl-1.0-plus",
+   "https://spdx.org/licenses/agpl-1.0-or-later",
+   "scancode:agpl-1.0-plus"
+  ]
+}

--- a/var/licenses/AGPL-3.0-only.json
+++ b/var/licenses/AGPL-3.0-only.json
@@ -53,6 +53,7 @@
         "GNU GENERAL PUBLIC LICENSE Version 3",
         "GNU AFFERO GENERAL PUBLIC LICENSE",
       "GNU Affero General Public License",
-      "GNU Affero General Public License-3.0 license"
+      "GNU Affero General Public License-3.0 license",
+      "Affero General Public License v3.0"
     ]
 }

--- a/var/licenses/APSL-2.0.json
+++ b/var/licenses/APSL-2.0.json
@@ -19,6 +19,7 @@
         "scancode:apsl-2.0",
         "osi:APSL-2.0",
         "APSL-2",
-        "apsl-2.0"
+      "apsl-2.0",
+      "APSL 2.0"
     ]
 }

--- a/var/licenses/Apache-1.1.json
+++ b/var/licenses/Apache-1.1.json
@@ -22,6 +22,9 @@
         "https://spdx.org/licenses/apache-1.1",
         "scancode:apache-1.1",
         "osi:Apache-1.1",
-        "apache-1.1"
+      "apache-1.1",
+      "Apache 1.1",
+      "Apache License v.1.1",
+      "APACHE1.1"
     ]
 }

--- a/var/licenses/Apache-2.0.json
+++ b/var/licenses/Apache-2.0.json
@@ -129,6 +129,9 @@
       "Apache License 2 License",
       "apache 2.0",
       "Apache License-2.0",
-      "Apache License-2"
+      "Apache License-2",
+      "Apache License 2.0 license",
+      "Apache License 2.0 License",
+      "Apache License v2 license"
     ]
 }

--- a/var/licenses/Apache-2.0.json
+++ b/var/licenses/Apache-2.0.json
@@ -132,6 +132,14 @@
       "Apache License-2",
       "Apache License 2.0 license",
       "Apache License 2.0 License",
-      "Apache License v2 license"
+      "Apache License v2 license",
+      "Apache License Version 2.0 January 2004",
+      "Apache Public License 2.0",
+      "the Apache License ASL Version 2.0",
+      "The Apache Software License Version 2.0",
+      "Apache License, Version 2.0.",
+      "Apache License Version 2.0, January 2004",
+      "Apache V2.0",
+      "Apache License2.0"
     ]
 }

--- a/var/licenses/Artistic-1.0.json
+++ b/var/licenses/Artistic-1.0.json
@@ -20,6 +20,7 @@
         "Artisticv1",
         "AFL-1",
         "AFLv1",
-        "artistic-1.0"
+      "artistic-1.0",
+      "Artistic License 1.0 Perl"
     ]
 }

--- a/var/licenses/BSD-1-Clause.json
+++ b/var/licenses/BSD-1-Clause.json
@@ -19,6 +19,7 @@
         "BSD 1C",
         "bsd-1-clause",
         "BSD 1-Clause",
-        "1-clause BSD License"
+      "1-clause BSD License",
+      "BSD One Clause License"
     ]
 }

--- a/var/licenses/BSD-2-Clause.json
+++ b/var/licenses/BSD-2-Clause.json
@@ -62,6 +62,9 @@
       "two-clause BSD",
       "simplified BSD",
       "Liberal BSD license",
-      "FreeBSD"
+      "FreeBSD",
+      "BSD 2 Clause FreeBSD",
+      "BSD2_CLAUSE",
+      "BSD license 2-clause"
     ]
 }

--- a/var/licenses/BSD-3-Clause-Attribution.LICENSE
+++ b/var/licenses/BSD-3-Clause-Attribution.LICENSE
@@ -1,0 +1,28 @@
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+     4. Redistributions of any form whatsoever must retain the following
+     acknowledgment: 'This product includes software developed by the
+     "Universidad de Palermo, Argentina" (http://www.palermo.edu/).'
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/var/licenses/BSD-3-Clause-Attribution.json
+++ b/var/licenses/BSD-3-Clause-Attribution.json
@@ -1,0 +1,19 @@
+{
+"meta": {
+    "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
+    "comment": ""
+  },
+  "name": "BSD Acknowledgment License",
+  "scancode_key": "bsd-ack",
+  "spdxid": "BSD-3-Clause-Attribution",
+  "aliases": [
+   "BSD 3-Clause License (attribution)",
+   "BSD Acknowledgment License",
+   "scancode://bsd-ack",
+   "BSD 3-Clause Attribution",
+   "BSD with attribution",
+    "scancode:bsd-ack",
+    "BSD 3 Clause Attribution",
+    "The Clear BSD"
+  ]
+}

--- a/var/licenses/BSD-3-Clause.json
+++ b/var/licenses/BSD-3-Clause.json
@@ -101,6 +101,14 @@
       "3C-BSD",
       "BSD-3 clause",
       "modified BSD",
-      "BSD-3C"
+      "BSD-3C",
+      "BSD-NEW",
+      "BSD3_CLAUSE",
+      "BSD 3-clause New License",
+      "BSD-3 Clause",
+      "The New BSD",
+      "the Zero-Clause BSD.",
+      "the Zero-Clause BSD",
+      "three clause BSD"
     ]
 }

--- a/var/licenses/BSD-4-Clause.json
+++ b/var/licenses/BSD-4-Clause.json
@@ -22,6 +22,9 @@
         "Original BSD license",
         "bsd-original",
         "BSD-4-Clause-License",
-        "BSD4.4 clause"
+      "BSD4.4 clause",
+      "BSD 4 Clause",
+      "BSD4_CLAUSE",
+      "4-clause BSD"
     ]
 }

--- a/var/licenses/Bitstream-Vera.json
+++ b/var/licenses/Bitstream-Vera.json
@@ -12,6 +12,9 @@
         "bitstream",
       "Bitstream",
       "Bitstream Vera Font",
-      "Bitstream Vera Fonts Copyright"
+      "Bitstream Vera Fonts Copyright",
+      "Bitstream Vera Font License",
+      "Bitstream Vera License 1.0",
+      "Bitstream Vera License v1.00"
     ]
 }

--- a/var/licenses/Bitstream-Vera.json
+++ b/var/licenses/Bitstream-Vera.json
@@ -11,6 +11,7 @@
         "Bitstream Vera",
         "bitstream",
       "Bitstream",
-      "Bitstream Vera Font"
+      "Bitstream Vera Font",
+      "Bitstream Vera Fonts Copyright"
     ]
 }

--- a/var/licenses/CNRI-Python.json
+++ b/var/licenses/CNRI-Python.json
@@ -21,6 +21,7 @@
         "http://www.opensource.org/licenses/CNRI-Python",
         "osi:CNRI-Python",
         "scancode:cnri-python-1.6",
-        "The CNRI portion of the multi-part Python License"
+      "The CNRI portion of the multi-part Python License",
+      "CNRI"
     ]
 }

--- a/var/licenses/EPL-1.0.json
+++ b/var/licenses/EPL-1.0.json
@@ -42,6 +42,7 @@
         "Eclipse Public License - v 1.0",
         "License :: OSI Approved :: Eclipse Public License 1.0",
         "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)",
-        "Eclipse Public License 1.0."
+      "Eclipse Public License 1.0.",
+      "Eclipse Public License Version 1.0"
     ]
 }

--- a/var/licenses/EPL-2.0.json
+++ b/var/licenses/EPL-2.0.json
@@ -35,6 +35,7 @@
         "osi:EPL-2.0",
         "Eclipse Public License 2.0 (EPL-2.0)",
         "License :: OSI Approved :: Eclipse Public License 2.0",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"
+      "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+      "Eclipse Public License Version 2.0"
     ]
 }

--- a/var/licenses/FTL.json
+++ b/var/licenses/FTL.json
@@ -21,6 +21,7 @@
         "scancode:freetype",
         "freetype",
         "Freetype",
-        "The FreeType Project LICENSE"
+      "The FreeType Project LICENSE",
+      "Freetype License"
     ]
 }

--- a/var/licenses/GPL-1.0-or-later.json
+++ b/var/licenses/GPL-1.0-or-later.json
@@ -27,6 +27,7 @@
    "scancode:gpl-1.0-plus",
    "GPLv1+",
    "GPLv1.0+",
-   "gpl-1.0-plus"
+    "gpl-1.0-plus",
+    "GPL 1+"
   ]
 }

--- a/var/licenses/GPL-2.0-only.json
+++ b/var/licenses/GPL-2.0-only.json
@@ -93,6 +93,7 @@
       "GNU General Public License-2.0-only",
       "GNU General Public Licensev2",
       "GPL-2.",
-      "GNU General Public License2"
+      "GNU General Public License2",
+      "GPL v2.0"
     ]
 }

--- a/var/licenses/GPL-2.0-only.json
+++ b/var/licenses/GPL-2.0-only.json
@@ -94,6 +94,9 @@
       "GNU General Public Licensev2",
       "GPL-2.",
       "GNU General Public License2",
-      "GPL v2.0"
+      "GPL v2.0",
+      "GNU GENERAL PUBLIC LICENSE Version 2 June 1991",
+      "The GNU General Public License Version 2",
+      "GPL Version 2"
     ]
 }

--- a/var/licenses/GPL-2.0-or-later.json
+++ b/var/licenses/GPL-2.0-or-later.json
@@ -65,6 +65,7 @@
       "GNU General Public License-2+",
       "GNU General Public License-2.0+",
       "https://spdx.org/licenses/GNU General Public License-2.0+.html",
-      "GNU General Public License-2.0+ https://spdx.org/licenses/GNU General Public License-2.0+.html"
+      "GNU General Public License-2.0+ https://spdx.org/licenses/GNU General Public License-2.0+.html",
+      "GNU General Public LicenseV2 +"
     ]
 }

--- a/var/licenses/GPL-3.0-only.json
+++ b/var/licenses/GPL-3.0-only.json
@@ -82,6 +82,7 @@
       "GPLv3 only",
       "GNU General Public License-3.0-only",
       "GPL-v3",
-      "GNU General Public License-3"
+      "GNU General Public License-3",
+      "GNU General Public License3"
     ]
 }

--- a/var/licenses/HPND.json
+++ b/var/licenses/HPND.json
@@ -20,6 +20,7 @@
         "historical",
         "License :: OSI Approved :: Historical Permission Notice and Disclaimer",
         "License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)",
-        "open source HPND License"
+      "open source HPND License",
+      "Historical Permission Notice and Disclaimer - sell variant"
     ]
 }

--- a/var/licenses/LGPL-2.0-only.json
+++ b/var/licenses/LGPL-2.0-only.json
@@ -24,6 +24,7 @@
     "LGPL v2",
     "GPL LGPL-2",
     "LGPLGNU LIBRARY GENERAL PUBLIC LICENSE Version 2",
-    "GNU LGPLv2"
+    "GNU LGPLv2",
+    "GNU Lesser General Public License2"
   ]
 }

--- a/var/licenses/LGPL-2.0-only.json
+++ b/var/licenses/LGPL-2.0-only.json
@@ -25,6 +25,7 @@
     "GPL LGPL-2",
     "LGPLGNU LIBRARY GENERAL PUBLIC LICENSE Version 2",
     "GNU LGPLv2",
-    "GNU Lesser General Public License2"
+    "GNU Lesser General Public License2",
+    "LGPL2.0"
   ]
 }

--- a/var/licenses/LGPL-2.1-only.json
+++ b/var/licenses/LGPL-2.1-only.json
@@ -66,6 +66,8 @@
         "LGPLv2.1 only",
       "Lesser General Public License (LGPL) (LGPL 2.1)",
       "GNU Lesser General Public Licensev2.1",
-      "GNU Lesser General Public License-2.1"
+      "GNU Lesser General Public License-2.1",
+      "LGPL2_1",
+      "LGPL version 2.1"
     ]
 }

--- a/var/licenses/LGPL-3.0-only.json
+++ b/var/licenses/LGPL-3.0-only.json
@@ -91,6 +91,7 @@
       "LGPL v3.0",
       "GNU Lesser General Public License-3",
       "LGPLv3.0",
-      "GNU Lesser General Public License 3.0 license"
+      "GNU Lesser General Public License 3.0 license",
+      "Lesser General Public License version 3"
     ]
 }

--- a/var/licenses/LGPL-3.0-only.json
+++ b/var/licenses/LGPL-3.0-only.json
@@ -90,6 +90,7 @@
       "GNU LGPLv3 (GNU Lesser General Public License 3.0) License",
       "LGPL v3.0",
       "GNU Lesser General Public License-3",
-      "LGPLv3.0"
+      "LGPLv3.0",
+      "GNU Lesser General Public License 3.0 license"
     ]
 }

--- a/var/licenses/LGPL-3.0-only.json
+++ b/var/licenses/LGPL-3.0-only.json
@@ -89,6 +89,7 @@
       "GNU Lesser General Public License v3",
       "GNU LGPLv3 (GNU Lesser General Public License 3.0) License",
       "LGPL v3.0",
-      "GNU Lesser General Public License-3"
+      "GNU Lesser General Public License-3",
+      "LGPLv3.0"
     ]
 }

--- a/var/licenses/LicenseRef-scancode-khronos.LICENSE
+++ b/var/licenses/LicenseRef-scancode-khronos.LICENSE
@@ -1,0 +1,18 @@
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject
+to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.

--- a/var/licenses/LicenseRef-scancode-khronos.json
+++ b/var/licenses/LicenseRef-scancode-khronos.json
@@ -7,6 +7,6 @@
   "scancode_key": "khronos",
   "spdxid": "LicenseRef-scancode-khronos",
   "aliases": [
-"dummy------remove-------me------------------------------------------------------------------------"
+    "Khronos"
   ]
 }

--- a/var/licenses/LicenseRef-scancode-khronos.json
+++ b/var/licenses/LicenseRef-scancode-khronos.json
@@ -1,0 +1,12 @@
+{
+"meta": {
+    "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
+    "comment": ""
+  },
+  "name": "Khronos License",
+  "scancode_key": "khronos",
+  "spdxid": "LicenseRef-scancode-khronos",
+  "aliases": [
+"dummy------remove-------me------------------------------------------------------------------------"
+  ]
+}

--- a/var/licenses/MIT.json
+++ b/var/licenses/MIT.json
@@ -45,6 +45,7 @@
         "MIT/X",
         "Expat (MIT)",
         "MIT / Expat",
-        "MIT License (MIT License)"
+      "MIT License (MIT License)",
+      "LICENSE-MIT"
     ]
 }

--- a/var/licenses/Python-2.0.1.json
+++ b/var/licenses/Python-2.0.1.json
@@ -7,6 +7,7 @@
     "scancode_key": "python-2.0.1", 
     "spdxid": "Python-2.0.1",
     "aliases": [
-        "python-2.0.1"
+      "python-2.0.1",
+      "Python License 2.0.1"
     ]
 }

--- a/var/licenses/Python-2.0.json
+++ b/var/licenses/Python-2.0.json
@@ -29,6 +29,7 @@
    "PSF-2.0 (Python Software Foundation License 2.0)",
     "PSF2",
     "Software Foundation License Version 2",
-    "Python Software Foundation License2"
+    "Python Software Foundation License2",
+    "Python SF 2"
   ]
 }

--- a/var/licenses/WTFPL.json
+++ b/var/licenses/WTFPL.json
@@ -24,9 +24,14 @@
         "Do What you Want",
         "http://www.wtfpl.net/about/",
         "http://sam.zoy.org/wtfpl/",
-        "scancode:wtfpl-2.0",
-        "wtfpl-2.0",
+      "scancode:wtfpl-2.0",
+      "wtfpl-2.0",
       "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE, Version 2.0",
-      "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE v2"
+      "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE v2",
+      "Do What The Fuck You Want To Public License", 
+      "Do What The Fuck You Want To Public License 2", 
+      "Do What The Fuck You Want To Public License 2.0", 
+      "Do What The Fuck You Want To Public License Version 2", 
+      "Do What The Fuck You Want To Public License-2.0"
     ]
 }

--- a/var/licenses/XFree86-1.1.json
+++ b/var/licenses/XFree86-1.1.json
@@ -12,6 +12,7 @@
         "XFree86 1.1 License",
         "scancode://xfree86-1.1",
         "scancode:xfree86-1.1",
-        "xfree86-1.1"
+      "xfree86-1.1",
+      "XFree86 1.1"
     ]
 }

--- a/var/licenses/Zlib.json
+++ b/var/licenses/Zlib.json
@@ -29,6 +29,12 @@
         "osi:Zlib",
       "zlib-libpng",
       "Zlib license",
-      "zlib license"
+      "zlib license",
+      "Zlib (simple permissive)",
+      "ZLIB_LIBPNG_LICENSE",
+      "Z-lib license",
+      "ZLIB_LICENSE",
+      "zlib-libpng-like-permissive",
+      "Zlib License"
     ]
 }

--- a/var/licenses/romic-exception.LICENSE
+++ b/var/licenses/romic-exception.LICENSE
@@ -1,0 +1,6 @@
+Additional permission under the GNU Affero GPL version 3 section 7:
+
+If you modify this Program, or any covered work, by linking or
+combining it with other code, such other code is not for that reason
+alone subject to any of the requirements of the GNU Affero GPL
+version 3.

--- a/var/licenses/romic-exception.json
+++ b/var/licenses/romic-exception.json
@@ -1,0 +1,11 @@
+{
+"meta": {
+    "disclaimer": "https://raw.githubusercontent.com/hesa/foss-licenses/main/var/disclaimer.md",
+    "comment": ""
+  },
+  "name": "Linking exception to AGPL 3.0",
+  "scancode_key": "linking-exception-agpl-3.0",
+  "spdxid": "romic-exception",
+  "aliases": [
+  ]
+}

--- a/var/licenses/x11-keith-packard.json
+++ b/var/licenses/x11-keith-packard.json
@@ -6,13 +6,14 @@
     "comment": "This license can be found in misc freedesktop/X11 related projects.",
     "name": "X11-Style (Keith Packard)",
     "scancode_key": "x11-keith-packard",
-    "spdxid": "LicenseRef-flame-x11-keith-packard",
+    "spdxid": "HPND-sell-variant",
     "aliases": [
         "X11-Style (Keith Packard)",
         "scancode://x11-keith-packard",
         "x11-keith-packard",
         "Keith Packard License",
-        "HPND-sell-variant"
+      "HPND-sell-variant",
+      "LicenseRef-flame-x11-keith-packard"
     ],
     "compatibility_as": "HPND"
 }


### PR DESCRIPTION
New licenses:
* AGPL-1.0-only
* AGPL-1.0-or-later
* Khronos 
* SD-3-Clause-Attribution
* romic-exception

New aliases for 
* 0BSD
* AGPL-3.0-only
* APSL-2.0
* Apache-1.1
* Apache-2.0
* Artistic-1.0
* BSD-1-Clause
* BSD-2-Clause
* BSD-3-Clause
* BSD-4-Clause
* Bitstream-Vera
* CNRI
* EPL-1.0
* EPL-2.0
* FTL
* GPL-1.0-or-later
* GPL-2.0-only
* GPL-2.0-or-later
* GPL-3.0-only
* HPDN
* LGPL-2.0-only
* LGPL-2.1-only
* LGPL-3.0-only
* MIT
* Python-2.0
* Python-2.0.1
* WTFPL
* XFree86-1.1
* Zlib
* khronos

New ambiguity aliases
* Apache
* BSD
* GNU Affero General Public License
* GPL
* LGPL
* LGPL
* MIT
* Mozilla

New compound aliases
* AGPL 3.0 WITH romic-exception
* GPL-2.0-only WITH Classpath-exception-2.0
* GPL-3.0-only WITH GCC-exception-3.1
