### PR TITLE
Fix 238: add support to output licenses with scancode keys instead of SPDX identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Current support:
 |Type            | Number |
 |----------------|--------|
 |Licenses        | 275    |
-|Aliases         | 3601   |
+|Aliases         | 3598   |
 |Compatibilities | 22     |
 |Operators       | 14     |
-|Ambiguities     | 167    |
+|Ambiguities     | 169    |
 |Compounds       | 112     |
 |No versions     | 38     |
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,9 +2,9 @@
 |Type            | Number |
 |----------------|--------|
 |Licenses        | 275    |
-|Aliases         | 3601   |
+|Aliases         | 3598   |
 |Compatibilities | 22     |
 |Operators       | 14     |
-|Ambiguities     | 167    |
+|Ambiguities     | 169    |
 |Compounds       | 112     |
 |No versions     | 38     |

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -92,6 +92,11 @@ def get_parser():
     parser_e = subparsers.add_parser(
         'license', help='Convert license to SPDX identifiers and syntax')
     parser_e.set_defaults(which='license', func=show_license)
+    parser_e.add_argument('-sc', '--scancode-keys',
+                          action='store_true',
+                          dest='scancode_keys',
+                          help='Output license with scancode keys instead of SPDX identifiers',
+                          default=False)
     parser_e.add_argument('license', type=str, nargs='+', help='license expression to fix')
 
     # full license
@@ -222,8 +227,9 @@ def compatibility(fl, formatter, args):
 
 def show_license(fl, formatter, args):
     validations = __validations(args)
+    scancode_keys = args.scancode_keys
     expression = fl.expression_license(' '.join(args.license), validations=validations, update_dual=(not args.no_dual_update))
-    return formatter.format_expression(expression, args.verbose)
+    return formatter.format_expression(expression, args.verbose, scancode_keys)
 
 def full_license(fl, formatter, args):
     expr_split = fl.expression_license(args.license)['identified_license'].split()

--- a/python/flame/format.py
+++ b/python/flame/format.py
@@ -442,9 +442,12 @@ class TextOutputFormatter(OutputFormatter):
             ret.append(f' * "{id_lic["queried_name"]}" -> "{id_lic["name"]}" via "{id_lic["identified_via"]}"')
         return "\n".join(ret)
 
-    def format_expression(self, expression, verbose=False):
+    def format_expression(self, expression, verbose=False, scancode_keys=False):
         ret = []
-        id_lic = expression['identified_license']
+        if scancode_keys:
+            id_lic = expression['identified_license_scancode_key']
+        else:
+            id_lic = expression['identified_license']
         ret.append(f'{id_lic}')
         if verbose:
             for identification in expression['identifications']:

--- a/python/flame/format.py
+++ b/python/flame/format.py
@@ -91,7 +91,7 @@ class OutputFormatter():
         """
         return None, None
 
-    def format_expression(self, expression, verbose=False):
+    def format_expression(self, expression, verbose=False, scancode_keys=False):
         """
         Return a formatted string of the compatibilities :func:`flame.license_db.FossLicenses.alias_list`.
 
@@ -329,7 +329,7 @@ class JsonOutputFormatter(OutputFormatter):
     def format_compat_list(self, all_compats, verbose=False):
         return json.dumps(all_compats, indent=4), None
 
-    def format_expression(self, expression, verbose=False):
+    def format_expression(self, expression, verbose=False, scancode_keys=False):
         return json.dumps(expression, indent=4), None
 
     def format_alias_list(self, all_aliases, verbose=False):
@@ -371,7 +371,7 @@ class YamlOutputFormatter(OutputFormatter):
     def format_compat_list(self, all_compats, verbose=False):
         return None, None
 
-    def format_expression(self, expression, verbose=False):
+    def format_expression(self, expression, verbose=False, scancode_keys=False):
         return yaml.safe_dump(expression), None
 
     def format_alias_list(self, all_aliases, verbose=False):

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -252,6 +252,24 @@ class FossLicenses:
         self.license_db[SCANCODE_KEYS_TAG] = scancode_keys
         self.license_db[LICENSE_OPERATORS_TAG] = self.__read_json(LICENSE_OPERATORS_FILE)['operators']
 
+    def __is_keyword(self, license_token):
+        return license_token in ['OR', 'AND', '(', ')', 'WITH']
+
+    def __expression_license_scancode(self, license_expression):
+        license_expression_scancode = []
+        fixed_license_expression = license_expression.replace('(', ' ( ').replace(')', ' ) ')
+        for license_token in fixed_license_expression.split(' '):
+            if not license_token:
+                continue
+            elif self.__is_keyword(license_token):
+                pass
+            else:
+                if license_token in self.license_db['licenses']:
+                    license_token = str(self.license_db['licenses'][license_token].get('scancode_key', license_token))
+            license_expression_scancode.append(license_token)
+
+        return ' '.join(license_expression_scancode)
+
     def __identify_license(self, name):
         if name in self.license_db[LICENSES_TAG]:
             ret_name = name
@@ -271,7 +289,7 @@ class FossLicenses:
             'identified_via': ret_id,
         }
 
-    def __init_needles(self, needles, needle_tag, license_expression, allow_letter=False):
+    def __init_needles(self, needles, needle_tag, allow_letter=False):
         if needle_tag not in self.needles_map:
             my_needles = []
             for needle in reversed(collections.OrderedDict(sorted(needles.items(), key=lambda x: len(x[0])))):
@@ -287,7 +305,7 @@ class FossLicenses:
 
     def __update_license_expression_helper(self, needles, needle_tag, license_expression, allow_letter=False):
         replacements = []
-        self.__init_needles(needles, needle_tag, license_expression, allow_letter)
+        self.__init_needles(needles, needle_tag, allow_letter)
         for c_needle in self.needles_map[needle_tag]:
             regexp = c_needle[0]
             needle = c_needle[1]
@@ -555,9 +573,11 @@ class FossLicenses:
                 parse_text = f'Parsing failed: {update_problem}.'
 
             raise FlameException(f'Could not parse the license "{license_expression}". {amb_text} {parse_text}')
+        simplified = str(self.simplify([license_parsed]))
         ret = {
             'queried_license': license_expression,
-            FLAME_IDENTIFIED_LICENSE_TAG: str(self.simplify([license_parsed])),
+            FLAME_IDENTIFIED_LICENSE_TAG: simplified,
+            'identified_license_scancode_key': self.__expression_license_scancode(simplified),
             'identifications': replacements,
             'ambiguities': ambiguities,
             'updated_license': updated_license,

--- a/tests/python/test_ldb.py
+++ b/tests/python/test_ldb.py
@@ -47,12 +47,15 @@ def test_aliases_bad_input():
 def test_expression_license():
     lic = fl.expression_license("GPL2+", update_dual=False)
     assert lic['identified_license'] == "GPL-2.0-or-later"
+    assert lic['identified_license_scancode_key'] == "gpl-2.0-plus"
 
     lic = fl.expression_license("GPL (v2 or later)", update_dual=False)
     assert lic['identified_license'] == "GPL-2.0-or-later"
+    assert lic['identified_license_scancode_key'] == "gpl-2.0-plus"
 
     lic = fl.expression_license("BSD-3-Clause and BSD3", update_dual=False)
     assert lic['identified_license'] == "BSD-3-Clause"
+    assert lic['identified_license_scancode_key'] == "bsd-new"
 
 def test_with_license_1():
     lic = fl.expression_license("BSD-3-Clause WITH SomeException", update_dual=False)
@@ -61,11 +64,13 @@ def test_with_license_1():
 def test_with_license_2():
     lic = fl.expression_license("BSD3 w/SomeException", update_dual=False)
     assert lic['identified_license'] == "BSD-3-Clause WITH SomeException"
+    assert lic['identified_license_scancode_key'] == "bsd-new WITH SomeException"
 
 def test_with_license_with_parent():
     """Test issue 69"""
     lic = fl.expression_license("GNU General Public License v2 or later (GPLv2+)", update_dual=False)
     assert lic['identified_license'] == "GPL-2.0-or-later"
+    assert lic['identified_license_scancode_key'] == "gpl-2.0-plus"
     pass
 
 def test_expression_license_types():

--- a/tests/shell/sanity-check.sh
+++ b/tests/shell/sanity-check.sh
@@ -101,7 +101,7 @@ check_presence()
         RET=$(( $RET + 1 ))
         _RET="FAIL"
         LICENSE_ERRORS="$LICENSE_ERRORS\n$REG_EXP_PRESENCE not present in $FILE"
-        exit
+        exit 1
     fi
 
     # check unpresence
@@ -350,7 +350,7 @@ check_presence MPL-2.0 " -e 2" " -e 1"
 check_presence MPL-2.0-no-copyleft-exception " -i -e 2 -e 'no[ \-]copyleft'" "-e 1"
 
 check_presence MS-PL " -i -e ms -e 'microsoft, pl'  -e 'microsoft public license' " " -i -e mpl"
-check_presence MS-RL  ' -i -e MS-RL -e "MS License,[ Va-z]* RL" -e "MS, Version RL"'   '' 
+check_presence MS-RL  ' -i -e MS-RL -e "MS License,[ Va-z]* RL" -e "MS, Version RL" -e Microsoft Reciprocal'   '' 
 
 check_presence MulanPSL-1.0 " -e 1" " -e 2"
 check_presence MulanPSL-2.0 " -e 2" " -e 1"
@@ -367,7 +367,7 @@ check_presence NTP " -i -e ntp -e network " ""
 
 check_presence OCaml-LGPL-linking-exception " -i -e ocaml" ""
 check_presence OCLC-2.0  ' -i -e OCLC'   ' -e 1' 
-check_presence OLFL-1.3  ' -i -e OLFL'   ' -e 2' 
+check_presence OLFL-1.3  ' -i -e OLFL -e Logistics'   ' -e 2' 
 check_presence ODC-By-1.0 " -i -e 1.0 -e odc" ""
 check_presence OFL-1.0 " -e 1.0 " " -e 1.1"
 check_presence OFL-1.1 " -e 1.1" " -e 1.0"
@@ -375,7 +375,7 @@ check_presence OGTSL " -i -e ogtsl -e Open\ Group -e ogts\ license -e opengroup"
 check_presence OLDAP-2.8 " -i -e oldap -e open[\ ]*ldap" ""
 check_presence OML " -i -e oml -e market -e fastcgi -e OM\ License" ""
 check_presence OpenSSL " -i -e openssl " ""
-check_presence OSC-1.0  ' -i -e OSC-1.0'   '' 
+check_presence OSC-1.0  ' -i -e OSC-1.0 -e OSC "[a-zA-Z]* 1.0" '   '' 
 check_presence OSET-PL-2.1  ' -i -e OSET -e OPL'   '' 
 check_presence OSL-1.0 " -i -e Open\ Software -e OSL-1 -e OSL\ 1 -e 'OSL[\, a-zA-Z ]*1.0'" " -e 2 -e 3"
 check_presence OSL-2.1 " -i -e Open\ Software -e OSL-2 -e OSL\ 2" " -e 3"

--- a/var/ambiguities.json
+++ b/var/ambiguities.json
@@ -149,7 +149,8 @@
             "aliases": [
                 "CDDL",
                 "CDDL-1",
-                "Common Development and Distribution License (CDDL)"
+                "Common Development and Distribution License (CDDL)",
+              "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)"
             ],
             "problem": "There are two versions of the CDDL license (CDDL-1.0 and CDDL-1.1). Without the version/variant of the license it is not possible to determine which of the versions is meant."    
         },
@@ -285,7 +286,7 @@
         },
         "SIL Open Font License": {
             "aliases": [
-                "SIL OPEN FONT LICENSE"
+              "SIL OPEN FONT LICENSE"
             ],
             "problem": "This license has different versions (1.0 and 1.1) and variantes. Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },
@@ -353,7 +354,8 @@
             "aliases": [
               "Unicode",
               "unicode-data",
-              "Unicode-data"
+              "Unicode-data",
+              "Unicode, Inc. License Agreement - Data Files and Software"
             ],
             "problem": "This license has different variants/versions (Unicode Terms of Use, Unicode-3.0, Unicode Inc License Agreement .... ). Without a version number clearly distinguishing the version it is not possible to determine which of the versions is meant."
         },

--- a/var/licenses/CDDL-1.1.json
+++ b/var/licenses/CDDL-1.1.json
@@ -18,7 +18,6 @@
         "scancode:cddl-1.1",
         "cddl-1.1",
         "CDDL v1.1",
-        "cddl-1-1",
-        "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)"
+        "cddl-1-1"
     ]
 }

--- a/var/licenses/OFL-1.1.json
+++ b/var/licenses/OFL-1.1.json
@@ -28,7 +28,6 @@
         "sil-1.1",
         "sil-ofl-1.1",
         "SIL Open Font 1.1",
-        "ofl-1-1",
-        "SIL OPEN FONT LICENSE"
+        "ofl-1-1"
     ]
 }

--- a/var/licenses/Unicode-DFS-2016.json
+++ b/var/licenses/Unicode-DFS-2016.json
@@ -21,7 +21,6 @@
         "Unicode-DFS License, Version 2016",
         "Unicode DFS, Version 2016",
         "Unicode-DFS, Version 2016",
-        "unicode-dfs-2016",
-        "Unicode, Inc. License Agreement - Data Files and Software"
+        "unicode-dfs-2016"
     ]
 }


### PR DESCRIPTION
fixes #238 
fixes #242 