### PR TITLE
Fix 213: remove osadl validation 

### DIFF
--- a/FLAME.md
+++ b/FLAME.md
@@ -61,13 +61,13 @@ BSD-3-Clause AND LicenseRef-flame-x11-keith-packard
 
 ## Get a license expression with compatible licenses
 
-You want an expression with licenses that are supported by [osadl_matrix](https://github.com/priv-kweihmann/osadl-matrix):
+You want an expression with licenses that are supported by typical compliance tools:
 ```
 $ flame compat "BSD3 & x11-keith-packard"
 BSD-3-Clause AND HPND
 ```
 
-You want an expression with licenses that are supported by [osadl_matrix](https://github.com/priv-kweihmann/osadl-matrix) from `BBSD3 & x11-keith-packard` with info on how the data was found:
+You want an expression with licenses that are supported by typical compliance tools from `BBSD3 & x11-keith-packard` with info on how the data was found:
 ```
 $ flame --verbose compat "BSD3 & x11-keith-packard"
 BSD-3-Clause AND HPND
@@ -110,7 +110,7 @@ or -> OR
 
 ## Compatibilities
 
-To list all licenses that has a license with same compatibility as an license known to [osadl_matrix](https://github.com/priv-kweihmann/osadl-matrix) (incomplete listing below):
+To list all licenses that has a license with same compatibility as an license known to typical compliance tools (incomplete listing below):
 ``` 
 $ flame compats
 LicenseRef-flame-x11-keith-packard -> HPND

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When you're working with compliance you are used to licenses called differently 
 
 ## License proliferation
 
-Another problem you face when working with compliance is the need to check whether the licenses in a combined work are compatible. One example is the [`X11-Style (Keith Packard)`](https://scancode-licensedb.aboutcode.org/x11-keith-packard.html) license, which really is the same license as the [Historical Permission Notice and Disclaimer - sell variant](https://spdx.org/licenses/HPND-sell-variant.html). `X11-Style (Keith Packard)` is not supported for example in the OSADL matrix, but `HPND-sell-variant` is. Again, a seasoned license engineer or lawyer knows which licenses are compatible and which are not, but we need to make it possible for a machine to assist us. 
+Another problem you face when working with compliance is the need to check whether the licenses in a combined work are compatible. One example is the [`X11-Style (Keith Packard)`](https://scancode-licensedb.aboutcode.org/x11-keith-packard.html) license, which really is the same license as the [Historical Permission Notice and Disclaimer - sell variant](https://spdx.org/licenses/HPND-sell-variant.html). `X11-Style (Keith Packard)` is not supported in typical compliance tools, but `HPND-sell-variant` is. Again, a seasoned license engineer or lawyer knows which licenses are compatible and which are not, but we need to make it possible for a machine to assist us. 
 
 # Status
 
@@ -70,7 +70,7 @@ This project aims at providing a database with:
 
 * "all" different names for a license in a database
 
-* mappings from one license to another license which is supported by the OSADL matrix
+* mappings from one license to another license which is supported by typical compliance tools
 
 and, to make the database easier to use:
 
@@ -124,8 +124,6 @@ made under our license (for the code and data).
 
 * [flict](https://github.com/vinland-technology/flict) - FOSS License Compatibility Tool 
 
-* [License Compatibility Matrix](https://www.osadl.org/Access-to-raw-data.oss-compliance-raw-data-access.0.html) - a matrix with license compatibilities
-
 * [scancode](https://github.com/nexB/scancode-toolkit) - ScanCode toolkit
 
 * [ScanCode LicenseDB](https://scancode-licensedb.aboutcode.org/) - a database with licenses
@@ -135,8 +133,6 @@ made under our license (for the code and data).
 * [Nexb](https://www.nexb.com/) for their FOSS compliance tools, especially [scancode](https://github.com/nexB/scancode-toolkit) and [ScanCode LicenseDB](https://scancode-licensedb.aboutcode.org/).
 
 * [Max Huber](https://github.com/maxhbr) for [LDBcollector](https://github.com/maxhbr/LDBcollector)
-
-* [OSADL](https://www.osadl.org) for their [License Compatibility Matrix](https://www.osadl.org/Access-to-raw-data.oss-compliance-raw-data-access.0.html)
 
 # Technical notes
 
@@ -183,7 +179,7 @@ As an example: "GPL-2.0-or-later" is replacde by "(GPL-2.0-only OR GPL-3.0-only"
 
 ## Insert same compatibility as another license
 
-Some licenses are not supported by the OSADL license matrix (e.g.
+Some licenses are not supported by typical compliance tools (e.g.
 "X11-Style (Keith Packard)") but the license is very similar and has
 the same compatibility towards other licenses as another license
 (e.g. "HPND").

--- a/python/docs/source/background.rst
+++ b/python/docs/source/background.rst
@@ -28,7 +28,7 @@ example is the `X11-Style (Keith Packard)
 license, which really is the same license as the `Historical
 Permission Notice and Disclaimer - sell variant
 <https://spdx.org/licenses/HPND-sell-variant.html>`_. `X11-Style
-(Keith Packard)` is not supported in for example the `OSADL matrix <https://github.com/priv-kweihmann/osadl-matrix>`_, but `HPND-sell-variant` is. Again, a seasoned license engineer or lawyer knows which licenses are compatible and not, but we need to make it possible for a machine to assist us. 
+(Keith Packard)` is not supported by typical compliance tools, but `HPND-sell-variant` is. Again, a seasoned license engineer or lawyer knows which licenses are compatible and not, but we need to make it possible for a machine to assist us. 
 
 Description
 ===========

--- a/python/flame/__main__.py
+++ b/python/flame/__main__.py
@@ -44,12 +44,6 @@ def get_parser():
                         help='Add licenses as found in the supplied directory',
                         default=None)
 
-    parser.add_argument('-lmf', '--license-matrix-file',
-                        type=str,
-                        dest='license_matrix_file',
-                        help='Supply license matrix to override OSADL\'s license compatibility matrix',
-                        default=None)
-
     parser.add_argument('-ndu', '--no-dual-update',
                         action='store_true',
                         help='do not update dual licenses (e.g. GPL-2.0-or-later -> GPL-2.0-only OR GPL-3.0-only)',
@@ -86,7 +80,6 @@ def get_parser():
     parser.add_argument('--validate-spdx', action='store_true', dest='validate_spdx', help='Validate that the resulting license expression is valid according to SPDX syntax', default=False)
     parser.add_argument('--validate-scancode', action='store_true', dest='validate_scancode', help='Validate that the resulting license expression is valid according to SPDX syntax and identifier exists in the Scancode license list', default=False)
     parser.add_argument('--validate-relaxed', action='store_true', dest='validate_relaxed', help='Validate that the resulting license expression is valid according to SPDX syntax, but allow non SPDX identifiers ', default=False)
-    parser.add_argument('--validate-osadl', action='store_true', dest='validate_osadl', help='Validate that the resulting licenses are supported by OSADL\'s compatibility matrix.', default=False)
 
     # license
     parser_e = subparsers.add_parser(
@@ -107,9 +100,9 @@ def get_parser():
 
     # compatibility
     parser_c = subparsers.add_parser(
-        'compat', help='Convert license to using licenses existing in the OSADL\'s matrix')
+        'compat', help='Convert license to a license typically supported by other compliance tools')
     parser_c.set_defaults(which='compat', func=compatibility)
-    parser_c.add_argument('license', type=str, nargs='+', help='license name to display')
+    parser_c.add_argument('license', type=str, nargs='+', help='license to convert')
 
     # simplify
     parser_s = subparsers.add_parser(
@@ -246,8 +239,6 @@ def __validations(args):
         validations.append(Validation.SPDX)
     if args.validate_relaxed:
         validations.append(Validation.RELAXED)
-    if args.validate_osadl:
-        validations.append(Validation.OSADL)
     if args.validate_scancode:
         validations.append(Validation.SCANCODE)
 
@@ -268,7 +259,6 @@ def main():
     config['additional-license-dir'] = args.additional_license_dir
     config['license-dir'] = args.license_dir
     config['flame-config'] = args.flame_config
-    config['license-matrix-file'] = args.license_matrix_file
 
     try:
         fl = FossLicenses(config=config)

--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -19,8 +19,6 @@ from flame.config import LICENSE_OPERATORS_FILE, LICENSE_COMPOUNDS_FILE, LICENSE
 from flame.exception import FlameException
 from jsonschema import validate
 
-import osadl_matrix
-
 json_schema = None
 
 FLAME_ALIASES_TAG = 'aliases'
@@ -56,7 +54,6 @@ LICENSE_SPLIT_RE_CLEAN = r' AND | OR |\(|\) | \||\&'
 class Validation(Enum):
     RELAXED = 1
     SPDX = 2
-    OSADL = 3
     SCANCODE = 4
 
 
@@ -665,7 +662,7 @@ class FossLicenses:
         return self.license(name)['license']['scancode_key']
 
     def compatibility_as_list(self) -> [str]:
-        """Return a list of all the licenses missing in the OSADL matrix but having a known similar compatibility.
+        """Return a list of all the licenses not supported by typical compliance tools but having a known similar compatibility.
 
         :Example:
 
@@ -874,7 +871,6 @@ class FossLicenses:
 
         compat_licenses = [x.strip() for x in re.split(LICENSE_SPLIT_RE, compat_license_expression)]
         compat_licenses = [x for x in compat_licenses if x]
-        compat_support = self.__validate_compatibilities_support(compat_licenses)
 
         self.__validate_license(validations, compat_license_expression)
 
@@ -885,7 +881,6 @@ class FossLicenses:
             'identification': expression_full,
             FLAME_IDENTIFIED_LICENSE_TAG: str(expression_full[FLAME_IDENTIFIED_LICENSE_TAG]),
             FLAME_COMPATIBLE_LICENSE_TAG: str(compat_license_expression),
-            'compat_support': compat_support,
         }
         self.compat_cache[cache_key] = ret
         return ret
@@ -898,32 +893,6 @@ class FossLicenses:
                 self.__validate_license_scancode(license_expression)
             if Validation.RELAXED in validations:
                 self.__validate_license_relaxed(license_expression)
-            if Validation.OSADL in validations:
-                compat_license_expression = self.expression_compatibility_as(license_expression)['compat_license']
-                compat_licenses = [x.strip() for x in re.split('\\(|OR|AND|\\)', compat_license_expression)]
-                compat_licenses = [x for x in compat_licenses if x]
-                compat_support = self.__validate_compatibilities_support(compat_licenses)
-                self.__validate_licenses_osadl(compat_support)
-
-    def __validate_compatibilities_support(self, licenses):
-        compat_support = {}
-        compat_support['licenses'] = []
-        all_supported = True
-        for lic in licenses:
-            support = self.__validate_compatibility_support(lic)
-            compat_support['licenses'].append({
-                'license': lic,
-                'supported': support,
-            })
-            all_supported = all_supported and support
-        compat_support['supported'] = all_supported
-
-        return compat_support
-
-    def __validate_compatibility_support(self, lic):
-        if not self.supported_licenses:
-            self.support_licenses = osadl_matrix.supported_licenses(self.license_matrix_file)
-        return lic in self.support_licenses
 
     def __validate_license_spdx(self, expr):
         """
@@ -957,13 +926,6 @@ class FossLicenses:
             lic = _lic.strip()
             if " " in lic.strip():
                 raise FlameException(f'Found license with multiple words "{lic}"')
-
-    def __validate_licenses_osadl(self, compat_supported):
-        """
-        """
-        if not compat_supported['supported']:
-            raise FlameException('Not all licenses supported by OSADL\'s compatibility matrix',
-                                 compat_supported)
 
     def __license_list(self, expr):
         SPDX_OPERATORS = ['AND', 'OR', 'WITH']

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,5 +5,4 @@
 jsonschema
 PyYAML
 license_expression
-osadl_matrix
 spdx_license_list

--- a/templates/README.tmpl
+++ b/templates/README.tmpl
@@ -47,7 +47,7 @@ When you're working with compliance you are used to licenses called differently 
 
 ## License proliferation
 
-Another problem you face when working with compliance is the need to check whether the licenses in a combined work are compatible. One example is the [`X11-Style (Keith Packard)`](https://scancode-licensedb.aboutcode.org/x11-keith-packard.html) license, which really is the same license as the [Historical Permission Notice and Disclaimer - sell variant](https://spdx.org/licenses/HPND-sell-variant.html). `X11-Style (Keith Packard)` is not supported for example in the OSADL matrix, but `HPND-sell-variant` is. Again, a seasoned license engineer or lawyer knows which licenses are compatible and which are not, but we need to make it possible for a machine to assist us. 
+Another problem you face when working with compliance is the need to check whether the licenses in a combined work are compatible. One example is the [`X11-Style (Keith Packard)`](https://scancode-licensedb.aboutcode.org/x11-keith-packard.html) license, which really is the same license as the [Historical Permission Notice and Disclaimer - sell variant](https://spdx.org/licenses/HPND-sell-variant.html). `X11-Style (Keith Packard)` is not supported in typical compliance tools, but `HPND-sell-variant` is. Again, a seasoned license engineer or lawyer knows which licenses are compatible and which are not, but we need to make it possible for a machine to assist us. 
 
 # Status
 
@@ -61,7 +61,7 @@ This project aims at providing a database with:
 
 * "all" different names for a license in a database
 
-* mappings from one license to another license which is supported by the OSADL matrix
+* mappings from one license to another license which is supported by typical compliance tools
 
 and, to make the database easier to use:
 
@@ -115,8 +115,6 @@ made under our license (for the code and data).
 
 * [flict](https://github.com/vinland-technology/flict) - FOSS License Compatibility Tool 
 
-* [License Compatibility Matrix](https://www.osadl.org/Access-to-raw-data.oss-compliance-raw-data-access.0.html) - a matrix with license compatibilities
-
 * [scancode](https://github.com/nexB/scancode-toolkit) - ScanCode toolkit
 
 * [ScanCode LicenseDB](https://scancode-licensedb.aboutcode.org/) - a database with licenses
@@ -126,8 +124,6 @@ made under our license (for the code and data).
 * [Nexb](https://www.nexb.com/) for their FOSS compliance tools, especially [scancode](https://github.com/nexB/scancode-toolkit) and [ScanCode LicenseDB](https://scancode-licensedb.aboutcode.org/).
 
 * [Max Huber](https://github.com/maxhbr) for [LDBcollector](https://github.com/maxhbr/LDBcollector)
-
-* [OSADL](https://www.osadl.org) for their [License Compatibility Matrix](https://www.osadl.org/Access-to-raw-data.oss-compliance-raw-data-access.0.html)
 
 # Technical notes
 
@@ -174,7 +170,7 @@ As an example: "GPL-2.0-or-later" is replacde by "(GPL-2.0-only OR GPL-3.0-only"
 
 ## Insert same compatibility as another license
 
-Some licenses are not supported by the OSADL license matrix (e.g.
+Some licenses are not supported by typical compliance tools (e.g.
 "X11-Style (Keith Packard)") but the license is very similar and has
 the same compatibility towards other licenses as another license
 (e.g. "HPND").

--- a/tests/python/test_compat.py
+++ b/tests/python/test_compat.py
@@ -52,5 +52,3 @@ def test_compat_validations():
     with pytest.raises(FlameException):
         c = fl.expression_compatibility_as('No no license', [Validation.SPDX], update_dual=False)
 
-    with pytest.raises(FlameException):
-        c = fl.expression_compatibility_as('No no license', [Validation.OSADL], update_dual=False)

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -30,15 +30,7 @@ def test_compat_default():
     compat = fl_default.expression_compatibility_as("MIT")
     assert compat['compat_license'] == 'MIT'
 
-def test_compat_matrix_mit():
-    compat = fl_default.expression_compatibility_as("MIT", validations=[Validation.OSADL])
-    assert compat['compat_license'] == 'MIT'
-
 def test_compat_matrix_unknown():
     compat = fl_default.expression_compatibility_as("unknown")
     assert compat['compat_license'] == 'unknown'
-
-def test_compat_matrix_unknown_validate():
-    with pytest.raises(FlameException):
-        compat = fl_default.expression_compatibility_as("unknown", validations=[Validation.OSADL])
 

--- a/tests/python/test_validate.py
+++ b/tests/python/test_validate.py
@@ -21,20 +21,6 @@ def test_supported():
     licenses = fl.licenses()
     assert len(licenses) == 7
 
-def test_osadl_validation():
-    fl.expression_license("MIT", validations=[Validation.OSADL])
-    
-    with pytest.raises(FlameException):
-        fl.expression_license("MIT2", validations=[Validation.OSADL])
-        
-    fl.expression_license("GPL-2.0-only WITH Classpath-exception-2.0", validations=[Validation.OSADL])
-        
-    with pytest.raises(FlameException):
-        fl.expression_license("GPL-2.0-only WITH NON_EXIST", validations=[Validation.OSADL])
-        
-    with pytest.raises(FlameException):
-        fl.expression_license("LicenseRef-scancode-unknown-license-reference", validations=[Validation.OSADL])
-
 def test_spdx_validation():
     fl.expression_license("MIT", validations=[Validation.SPDX])
     


### PR DESCRIPTION
Remove `--validate-osadl` and any use of a license matrix.

fixes #241 
fixes #213 