### PR TITLE
fix: correct 'ambigous_license' to 'ambiguous_license' typo

### DIFF
--- a/python/flame/license_db.py
+++ b/python/flame/license_db.py
@@ -455,7 +455,7 @@ class FossLicenses:
           "ambiguities": [
             {
               "license": "GNU & GPL-2.0-or-later",
-              "ambigous_license": "GNU",
+              "ambiguous_license": "GNU",
               "problem": "There a couple of licenses related to the GNU project. Without the name of the license and version number it is not possible to determine which of the versions is meant.",
               "description": "An ambiguity was identified in \"GNU & GPL-2.0-or-later\". The ambiguous license is \"GNU\". Problem: There a couple of licenses related to the GNU project. Without the name of the license and version number it is not possible to determine which of the versions is meant."
             }
@@ -522,7 +522,7 @@ class FossLicenses:
                 problem = self.license_db[AMBIG_TAG]["ambiguities"][real_lic]["problem"]
                 ambiguities.append({
                     'license': ret['license_expression'],
-                    'ambigous_license': real_lic,
+                    'ambiguous_license': real_lic,
                     'problem': problem,
                     'description': f'{about_license} Problem: {problem}',
                 })

--- a/tests/python/test_values.py
+++ b/tests/python/test_values.py
@@ -95,12 +95,12 @@ def test_ambigs():
                 logging.debug(f'assert expression: {expression}')
                 logging.debug(f'assert queried:    {expression["queried_license"]}')
                 logging.debug(f'assert identified: {expression["identified_license"]}')
-                logging.debug(f'assert ambigous:   {len(expression["ambiguities"])}')
-                logging.debug(f'assert ambigous:   {expression["ambiguities"][0]["ambigous_license"]}')
-                logging.debug(f'assert {expression["ambiguities"][0]["ambigous_license"]} == {k}')
+                logging.debug(f'assert ambiguous:   {len(expression["ambiguities"])}')
+                logging.debug(f'assert ambiguous:   {expression["ambiguities"][0]["ambiguous_license"]}')
+                logging.debug(f'assert {expression["ambiguities"][0]["ambiguous_license"]} == {k}')
                 logging.debug(f'assert k:          {k}')
                 logging.debug(f'assert a0:         {expression["ambiguities"][0]}')
-                assert expression['ambiguities'][0]['ambigous_license'] == k
+                assert expression['ambiguities'][0]['ambiguous_license'] == k
             except flame.exception.FlameException as e:
                 # flamexception thrown 
                 logging.debug("e: " + str(type(e)))


### PR DESCRIPTION
## Summary
Fix typo in license identifier key: `ambigous_license` → `ambiguous_license`.

## Changes
- `python/flame/license_db.py` lines 458, 525: Fix key name in dictionary
- `tests/python/test_values.py` lines 98-103: Update test assertions + fix debug log strings ('assert ambigous' → 'assert ambiguous')

## Issue
Fixes issue #250